### PR TITLE
add custom style to sphinx-tab

### DIFF
--- a/src/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
+++ b/src/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
@@ -1,6 +1,7 @@
 /* Provided by the Sphinx base theme template at build time */
 @import "../basic.css";
 @import url('https://fonts.googleapis.com/css2?family=Inconsolata:wght@600&display=swap');
+@import "../tabs.css";
 
 
 @font-face {
@@ -93,6 +94,18 @@ p.rubric {
     margin-bottom: 0.75em;
 }
 
+
+/*
+###############
+   Sphinx-tab 
+###############
+*/
+.sphinx-tabs-panel, p{
+  font-weight: 100;
+  font-family: 'Source Sans Pro', sans-serif;
+  font-size: 1rem;
+  font-style: var(--pst-font-family-base-system);
+}
 
 
 /*


### PR DESCRIPTION
Fix #50 #44 override the sphinx tab class in the ansys-sphinx-theme.css to alter the font size and weight. 