### PR TITLE
Adding plotly support to gallery examples.

### DIFF
--- a/src/ansys_sphinx_theme/layout.html
+++ b/src/ansys_sphinx_theme/layout.html
@@ -4,7 +4,9 @@
 {%- block css %}
     {{ super() }}
     {# adding support for plotly in gallery examples #}
-    <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+    {% if theme_use_plotly %}
+        <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+    {% endif %}
     {% if theme_show_breadcrumbs %}
         <link href="{{ pathto('_static/css/breadcrumbs.css', 1) }}" rel="stylesheet">
     {% endif %}

--- a/src/ansys_sphinx_theme/layout.html
+++ b/src/ansys_sphinx_theme/layout.html
@@ -3,6 +3,8 @@
 {# Append our custom CSS after the bootstrap stylesheet so we can override where necessary #}
 {%- block css %}
     {{ super() }}
+    {# adding support for plotly in gallery examples #}
+    <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
     {% if theme_show_breadcrumbs %}
         <link href="{{ pathto('_static/css/breadcrumbs.css', 1) }}" rel="stylesheet">
     {% endif %}

--- a/src/ansys_sphinx_theme/theme.conf
+++ b/src/ansys_sphinx_theme/theme.conf
@@ -9,3 +9,4 @@ show_breadcrumbs = True
 show_icons = True
 hidden_icons =
 additional_breadcrumbs =
+use_plotly=True


### PR DESCRIPTION
Updating layout.html to include script to render plotly code in gallery examples.

Sooo... basically, based on:

* https://github.com/readthedocs/sphinx_rtd_theme/issues/788#issuecomment-608992554
* https://stackoverflow.com/questions/24168851/using-browserify-and-requirejs-on-the-same-page/25586213#25586213
* https://stackoverflow.com/questions/46269345/embed-plotly-graph-in-a-sphinx-doc

I have modified the layout.html to load Plotly (it injects it).

P.D. @jorgepiloto you are everywhere!!

Close https://github.com/pyansys/pymapdl/issues/1211 
