### PR TITLE
Modify make.bat file to build pdf with all .tex file

### DIFF
--- a/doc/make.bat
+++ b/doc/make.bat
@@ -35,7 +35,8 @@ goto end
 :pdf
 	%SPHINXBUILD% -M latex %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
 	cd "%BUILDDIR%\latex"
-	pdflatex ansys_sphinx_theme.tex --interaction=nonstopmode
+	for %%f in (*.tex) do (
+	pdflatex "%%f" --interaction=nonstopmode)
 	
 :end
 popd


### PR DESCRIPTION
Modified make.bat file  to take all .tex file to build pdf (without interaction).