### PR TITLE
Change the color of output cell for sphinx-gallery

### DIFF
--- a/src/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
+++ b/src/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
@@ -2,6 +2,7 @@
 @import "../basic.css";
 @import url('https://fonts.googleapis.com/css2?family=Inconsolata:wght@600&display=swap');
 @import "../tabs.css";
+@import "../sg_gallery.css";
 
 
 @font-face {
@@ -83,6 +84,8 @@ html[data-theme="light"] {
   --pst-color-link-hover: #005B81;
   --pst-color-inline-code: rgb(232, 62, 140);
   --pst-color-target: rgb(255, 255, 255);
+  /* color for sphinx-gallery-code output*/
+  --pst-color-codeout: #fafae2;
 }
 
 html[data-theme="dark"] {
@@ -92,7 +95,7 @@ html[data-theme="dark"] {
   --pst-color-primary: rgb(255, 183, 27);
   --pst-color-secondary: rgb(200, 146, 17);
   --pst-color-success: rgb(72, 135, 87);
-  --pst-color-text-base: rgb(201, 209, 217);
+  --pst-color-text-base: rgb(217, 215, 201);
   --pst-color-text-muted: rgb(192, 192, 192);
   --pst-color-border: rgb(192, 192, 192);
   --pst-color-shadow: var(--pst-color-background);
@@ -115,6 +118,8 @@ html[data-theme="dark"] {
   --pst-color-link-hover: #005B81;
   --pst-color-inline-code: rgb(221, 158, 194);
   --pst-color-target: rgb(71, 39, 0);
+  /* color for sphinx-gallery-code output*/
+  --pst-color-codeout: #6c757d;
 }
 
 .admonition, div.admonition{
@@ -428,3 +433,12 @@ a > code.download
     text-decoration: none;
     font-weight: normal;
 }
+
+/*
+########################
+   ReST :download: links
+########################
+*/
+.sphx-glr-script-out .highlight pre{
+  background-color:  var(--pst-color-codeout) !important;
+  }

--- a/src/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
+++ b/src/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
@@ -436,7 +436,7 @@ a > code.download
 
 /*
 ########################
-   ReST :download: links
+   Sphinx gallery output
 ########################
 */
 .sphx-glr-script-out .highlight pre{


### PR DESCRIPTION
This PR will fix the code output cell color of sphinx gallery. in dark mode. Light mode color retained as it is. 
![out-dark](https://user-images.githubusercontent.com/104772255/180772356-e8ac28c4-81ce-4506-bfc8-d0c78d3e9508.PNG)
## Note :

The shade/color of texts and the background will change soon as discussed with documentation team once they are ready with the color codes. 