### PR TITLE
Fix bold to ``<strong>`` tags

### DIFF
--- a/src/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
+++ b/src/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
@@ -554,6 +554,12 @@ html[data-theme="light"] .highlight .o {
   font-weight: bold;
 }
 
+/*
+#############################
+Bold font weight for **code**
+#############################
+*/
+
 b, strong {
   font-weight: 900;
 }

--- a/src/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
+++ b/src/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
@@ -553,3 +553,7 @@ html[data-theme="light"] .highlight .o {
   color: #B35000;
   font-weight: bold;
 }
+
+b, strong {
+  font-weight: 900;
+}


### PR DESCRIPTION
``<strong>``  tags are set to bolder but it was not showing bold. Font-weight: bolder means "One relative font weight heavier than the parent element" ([MDN article](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#values)). So giving ``strong`` tag to font_weight : 900 directly. Fix #79 
![bold](https://user-images.githubusercontent.com/104772255/183939724-34ec95e3-8dc9-49cf-805a-ae5999c27f78.PNG)
![bold-render](https://user-images.githubusercontent.com/104772255/183939728-0fa1e7a0-49d4-4d30-9289-3b0dee049279.PNG)
