### PR TITLE
Fix CNAME in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -46,4 +46,4 @@ allowlist_externals=*
 commands =
     sphinx-build -d "{toxworkdir}/doc_doctree" doc/source "{toxworkdir}/doc_out" --color -vW -bhtml
     touch "{toxworkdir}/doc_out/.nojekyll"
-    bash -c 'echo "sphinxdocs.pyansys.com" > "{toxworkdir}/doc_out/CNAME"'
+    bash -c 'echo "sphinxdocs.ansys.com" > "{toxworkdir}/doc_out/CNAME"'


### PR DESCRIPTION
We forgot to update the content of CNAME content when we migrated this from PyAnsys to Ansys organization.

This commit should be merged into main and then cherry-picked into release/0.5, @Revathyvenugopal162.