### PR TITLE
Add the deprecation styles

### DIFF
--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -28,7 +28,7 @@ Consider using the ``conf.py`` for this repository:
 
 .. literalinclude:: ../conf.py
    :language: python
-   
+
 .. toctree::
    :hidden:
    :maxdepth: 2

--- a/src/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
+++ b/src/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
@@ -856,3 +856,13 @@ margin-left: auto;
 margin-right: auto;
 font-family: var(--pst-font-family-base);
 }
+
+div.deprecated {
+  border-color: var(--pst-color-danger);
+  background-color: #dc354514;
+}
+
+div.versionadded {
+  border-color: var(--pst-color-success);
+  background: #88ca881f;
+}


### PR DESCRIPTION
Fix #121 

## Dark theme
![depre-dark](https://user-images.githubusercontent.com/104772255/213991291-121e8384-0d1f-40ff-af92-3945779adacf.PNG)

## Light theme
![ligh depre](https://user-images.githubusercontent.com/104772255/213991293-1d0293b0-66fc-4f5b-9fa8-75bc6b185b63.PNG)
