### PR TITLE
Add the default navigation collapse with the theme.

### DIFF
--- a/src/ansys_sphinx_theme/__init__.py
+++ b/src/ansys_sphinx_theme/__init__.py
@@ -79,6 +79,7 @@ def setup_default_html_theme_options(app):
     app.config.html_theme_options.setdefault(
         "navbar_end", ["version-switcher", "theme-switcher", "navbar-icon-links"]
     )
+    app.config.html_theme_options.setdefault("collapse_navigation", "True")
 
 
 def setup(app: sphinx.application.Sphinx) -> Dict:

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/_templates/autosummary/class.rst
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/_templates/autosummary/class.rst
@@ -1,4 +1,4 @@
-{{ fullname | escape | underline}}
+{{ objname | escape | underline}}
 
 .. currentmodule:: {{ module }}
 


### PR DESCRIPTION
Fix #194
# _Before_ : With fullname for autopai
![collapse_before](https://user-images.githubusercontent.com/104772255/218511854-c5154597-4137-44b8-b062-7a40ebfcf008.PNG)
# _After_ : with obj name for autoapi
![navigation](https://user-images.githubusercontent.com/104772255/218511922-8e4daa4e-766f-4837-9c8e-49bf3b2f5858.PNG)
