### PR TITLE
DOC: use default meilisearch credentials

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -12,8 +12,6 @@ env:
   PACKAGE_NAME: 'ansys-sphinx-theme'
   PACKAGE_NAMESPACE: 'ansys_sphinx_theme'
   DOCUMENTATION_CNAME: 'sphinxdocs.ansys.com'
-  MEILISEARCH_HOST_NAME: ${{ secrets.MEILISEARCH_HOST_NAME}}
-  MEILISEARCH_API_KEY: ${{ secrets.MEILISEARCH_API_KEY}}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -65,8 +65,6 @@ html_theme_options = {
         "version_match": get_version_match(__version__),
     },
     "use_meilisearch": {
-        "host": os.getenv("MEILISEARCH_HOST_NAME", ""),
-        "api_key": os.getenv("MEILISEARCH_API_KEY", ""),
         "index_uids": {
             "ansys-ansys-sphinx-theme-sphinx-docs": "ansys-sphinx-theme",
             "pyansys-docs-all-public": "PyAnsys",

--- a/doc/source/user_guide/options.rst
+++ b/doc/source/user_guide/options.rst
@@ -25,8 +25,8 @@ For example:
        "show_prev_next": False,
        "show_breadcrumbs": True,
        "additional_breadcrumbs": [
-        ("Ansys", "https://www.ansys.com/"),
-        ],
+           ("Ansys", "https://www.ansys.com/"),
+       ],
    }
 
 When you are on the documentation's homepage, the breadcrumb shows the homepage
@@ -118,10 +118,12 @@ This dictionary should contain the following keys:
 #. ``host``: The host name of your MeiliSearch instance. It is hosted at
     https://search.pyansys.com on port 443 (default).
     You can set this to an environment variable using 
-    ``os.getenv()`` for added security.
+    ``os.getenv()`` for added security. If no value is provided, the default
+    public host for PyAnsys is used.
 
 #. ``api_key``: The API key for your MeiliSearch instance.
-   You can also set this to an environment variable using ``os.getenv()``.
+   You can also set this to an environment variable using ``os.getenv()``. If no
+   value is provided, the default API public API key for PyAnsys is used.
 
 #. ``index_uids``: A dictionary that provides a mapping between the unique
    identifier (UID) of an index and its 
@@ -155,8 +157,6 @@ Here is the example configuration of using MeiliSearch in
     
     html_theme_options = {
     "use_meilisearch": {
-        "host": os.getenv("MEILISEARCH_HOST_NAME", ""),
-        "api_key": os.getenv("MEILISEARCH_API_KEY", ""),
         "index_uids": {
             "ansys-ansys-sphinx-theme-sphinx-docs": "ansys-sphinx-theme",
             "pyansys-docs-all-public": "PyAnsys",

--- a/doc/source/user_guide/options.rst
+++ b/doc/source/user_guide/options.rst
@@ -123,7 +123,7 @@ This dictionary should contain the following keys:
 
 #. ``api_key``: The API key for your MeiliSearch instance.
    You can also set this to an environment variable using ``os.getenv()``. If no
-   value is provided, the default API public API key for PyAnsys is used.
+   value is provided, the default public API key for PyAnsys is used.
 
 #. ``index_uids``: A dictionary that provides a mapping between the unique
    identifier (UID) of an index and its 

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/components/search-field.html
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/components/search-field.html
@@ -30,8 +30,8 @@
       // Initialize the MeiliSearch bar with the given API key and host
       // inspect the first value of index UID as default
       let theSearchBar = docsSearchBar({
-        hostUrl: {{ HOST_URL }},
-        apiKey: {{ API_KEY }},
+        hostUrl: "{{ HOST_URL }}",
+        apiKey: "{{ API_KEY }}",
         indexUid: "{{ theme_use_meilisearch.index_uids.items()|first|first }}",
         inputSelector: '#search-bar-input, #indexUidSelector',
         enableDarkMode: 'auto',

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/components/search-field.html
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/components/search-field.html
@@ -18,11 +18,20 @@
     <!-- Include the MeiliSearch JavaScript library for the search bar -->
     <script src="https://cdn.jsdelivr.net/npm/docs-searchbar.js@latest/dist/cdn/docs-searchbar.min.js"></script>
     <script>
+      // If no credentials provided, use the default ones
+      {% if not theme_use_meilisearch.host and not theme_use_meilisearch.api_key %}
+        {% set HOST_URL = "https://search.pyansys.com" %}
+        {% set API_KEY = "A1Qxly2sls6g1rb1sIKEVEtE7R1UsHad0VgqnvKhD5nhBNf5de" %}
+      {% else %}
+        {% set HOST_URL = theme_use_meilisearch.host %}
+        {% set API_KEY = theme_use_meilisearch.api_key %}
+      {% endif %}
+      
       // Initialize the MeiliSearch bar with the given API key and host
       // inspect the first value of index UID as default
       let theSearchBar = docsSearchBar({
-        hostUrl: "{{ theme_use_meilisearch.host }}" ,
-        apiKey: "{{ theme_use_meilisearch.api_key }}" ,
+        hostUrl: {{ HOST_URL }},
+        apiKey: {{ API_KEY }},
         indexUid: "{{ theme_use_meilisearch.index_uids.items()|first|first }}",
         inputSelector: '#search-bar-input, #indexUidSelector',
         enableDarkMode: 'auto',

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/theme.conf
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/theme.conf
@@ -12,4 +12,4 @@ hidden_icons =
 additional_breadcrumbs =
 use_edit_page_button = True
 switcher =
-use_meilisearch=
+use_meilisearch =


### PR DESCRIPTION
This pull-request allows to use the default meilisearch credentials for PyAnsys public documentation. Note this API key is already public, no need to hide it.