### PR TITLE
MAINT: Add sphinx card configuration according to screen size

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -2,10 +2,7 @@
 
 from datetime import datetime
 import os
-from pathlib import Path
-from typing import List
 
-import requests
 from sphinx.builders.latex import LaTeXBuilder
 
 LaTeXBuilder.supported_image_types = ["image/png", "image/pdf", "image/svg+xml"]
@@ -21,10 +18,6 @@ from ansys_sphinx_theme import (
     latex,
     watermark,
 )
-
-THIS_PATH = Path(__file__).parent.resolve()
-
-EXAMPLE_PATH = (THIS_PATH / "examples" / "sphinx_examples").resolve()
 
 # Project information
 project = "ansys_sphinx_theme"
@@ -145,7 +138,19 @@ latex_elements = {"preamble": latex.generate_preamble(html_title)}
 notfound_context = {
     "body": generate_404(),
 }
+
 notfound_no_urls_prefix = True
+
+# ONLY FOR ANSYS-SPHINX-THEME
+
+from pathlib import Path
+from typing import List
+
+import requests
+
+THIS_PATH = Path(__file__).parent.resolve()
+
+EXAMPLE_PATH = (THIS_PATH / "examples" / "sphinx_examples").resolve()
 
 
 def extract_example_links(

--- a/doc/source/examples/sphinx-design.rst
+++ b/doc/source/examples/sphinx-design.rst
@@ -17,7 +17,7 @@ please refer `sphinx design <https://sphinx-design.readthedocs.io/en/latest/inde
         .. literalinclude:: sphinx_examples/{{ filename }}
            :language: rst
         
-    This directive renders the as follow:
+        This directive renders as follows:
 
         .. include:: sphinx_examples/{{ filename }}
 

--- a/doc/source/examples/sphinx-design.rst
+++ b/doc/source/examples/sphinx-design.rst
@@ -17,7 +17,7 @@ please refer `sphinx design <https://sphinx-design.readthedocs.io/en/latest/inde
         .. literalinclude:: sphinx_examples/{{ filename }}
            :language: rst
         
-This directive renders as follows:
+    This directive renders as follows:
 
         .. include:: sphinx_examples/{{ filename }}
 

--- a/doc/source/examples/sphinx-design.rst
+++ b/doc/source/examples/sphinx-design.rst
@@ -17,7 +17,7 @@ please refer `sphinx design <https://sphinx-design.readthedocs.io/en/latest/inde
         .. literalinclude:: sphinx_examples/{{ filename }}
            :language: rst
         
-        This directive renders as follows:
+This directive renders as follows:
 
         .. include:: sphinx_examples/{{ filename }}
 

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -28,6 +28,7 @@ Consider using the ``conf.py`` for this repository:
 
 .. literalinclude:: ../conf.py
    :language: python
+   :end-before: # ONLY FOR ANSYS-SPHINX-THEME
 
 .. toctree::
    :hidden:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,6 @@ doc = [
     "sphinx-copybutton==0.5.2",
     "sphinx-notfound-page==0.8.3",
     "sphinx-design==0.4.1",
-    "bs4==0.0.1",
-    "html5lib==1.1",
     "requests==2.31.0",
     "sphinx-jinja==2.0.2",
 ]

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
@@ -931,8 +931,14 @@ html[data-theme="dark"] .sd-card-img-top[src*=".png"] {
 /* Media query for small-sized screens */
 @media screen and (max-width: 576px) {
   .sd-card .sd-card-header {
-    font-size: var(--pst-font-size-h6);
-    padding: 0.3rem 0rem 0.3rem 0rem;
+    font-size: var(--pst-font-size-h5);
+  }
+  .sd-card {
+    padding: 5px 5px 5px 5px;
+  }
+  .sd-sphinx-override,
+  .sd-sphinx-override * {
+    box-sizing: content-box !important;
   }
 }
 

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
@@ -838,10 +838,9 @@ Sphinx design
   font-size: medium;
   flex: auto;
 }
-/*
-Sphinx-design tab
-*/
+/* Sphinx-design tab */
 
+/* Common styles for all screen sizes */
 .sd-tab-set > input:not(.focus-visible) + label {
   outline: none;
   font-size: large;
@@ -869,10 +868,23 @@ Sphinx-design tab
   border-color: var(--pst-color-text-base);
 }
 
-/*
-Sphinx-design card
-*/
+/* Media query for medium-sized screens */
+@media screen and (max-width: 768px) {
+  .sd-tab-set > input:not(.focus-visible) + label {
+    font-size: medium;
+  }
+}
 
+/* Media query for small-sized screens */
+@media screen and (max-width: 576px) {
+  .sd-tab-set > input:not(.focus-visible) + label {
+    font-size: small;
+  }
+}
+
+/* Sphinx-design card */
+
+/* Common styles for all screen sizes */
 .sd-card .sd-card-text {
   font-family: var(--pst-font-family-base) !important;
 }
@@ -902,10 +914,26 @@ html[data-theme="dark"] .sd-card-img-top[src*=".png"] {
   filter: invert(0.82) brightness(0.8) contrast(1.2);
 }
 
+/* Common styles for all screen sizes */
 .sd-card {
   border-radius: 0;
   padding: 10px 10px 10px 10px;
   font-family: var(--pst-font-family-base) !important;
+}
+
+/* Media query for medium-sized screens */
+@media screen and (max-width: 768px) {
+  .sd-card .sd-card-header {
+    font-size: var(--pst-font-size-h6);
+  }
+}
+
+/* Media query for small-sized screens */
+@media screen and (max-width: 576px) {
+  .sd-card .sd-card-header {
+    font-size: var(--pst-font-size-h6);
+    padding: 0.3rem 0rem 0.3rem 0rem;
+  }
 }
 
 /*

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
@@ -769,6 +769,11 @@ i.fa-square-github:before {
   color: white;
 }
 
+.navbar-icon-links {
+  font-size: 1.5rem;
+  color: white;
+}
+
 /*
 ##############################
 image padding before and after 


### PR DESCRIPTION
Resolve part of #256 
![image](https://github.com/ansys/ansys-sphinx-theme/assets/104772255/c2ad050d-6aab-4f2c-97b3-a2b2053967aa)

- The sphinx card with content in footer is having the issue with  screen size, so adapted only for the card header 
and size. https://cheatsheets.docs.pyansys.com/ rendering very good on all screen.
- Update the script to render all examples of the card inside the example section for manual check and also as examples
- Adapt the icon with same font size
### 
![image](https://github.com/ansys/ansys-sphinx-theme/assets/104772255/ad9dba00-abc7-46cf-83cb-aa43b8ec6664)

![image](https://github.com/ansys/ansys-sphinx-theme/assets/104772255/ccec5b89-76dd-4188-bcd4-af2c185f9b84)

