### PR TITLE
maint: fix normal table rendering styles

### DIFF
--- a/doc/source/examples/table.rst
+++ b/doc/source/examples/table.rst
@@ -6,6 +6,33 @@ The table directive with ansys sphinx theme allows for rendering of tables.
 There are different types of tables, such as the data table, longtable-centered, 
 and table-centered, each serving different purposes.
 
+Normal table
+------------
+
+
+.. table:: Truth table for "not"
+   :widths: auto
+   :align: center
+
+   +--------------------+------------------------+----------------------------------+
+   |     **A**          |    **B**               |       **C**                      |
+   +====================+========================+==================================+
+   |                    ||    True               ||         False                   |
+   |        False       ||    False              ||         True                    |
+   +--------------------+------------------------+----------------------------------+
+   |                    ||    True               ||         False                   |
+   |       False        ||    False              ||         True                    |
+   +--------------------+------------------------+----------------------------------+
+   |                    ||                       ||                                 |
+   |                    ||     True              ||                                 |
+   |                    |                        ||                                 |
+   |        False       +------------------------+|          False                  +
+   |                    ||    True               ||                                 |
+   |                    ||    False              ||          True                   |
+   +--------------------+------------------------+----------------------------------+
+
+
+
 Data table
 ----------
 This is an example of a data table that can be rendered using the table directive.

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
@@ -259,14 +259,14 @@ Table
 ########
 */
 
-table {
+.table {
   width: 100%;
   max-width: 100%;
   border-spacing: 0;
   border-collapse: collapse;
   overflow: hidden;
   vertical-align: middle;
-
+  color: var(--pst-color-text-base);
   /* Disabling scroll bars */
   overflow-y: scroll;
   scrollbar-width: none; /* Firefox */


### PR DESCRIPTION
fix #272 

### rendering
![image](https://github.com/ansys/ansys-sphinx-theme/assets/104772255/18b884b8-494d-4e82-bb03-f4d93e406541)
