### PR TITLE
Fix dataframe rendering in dark mode

### DIFF
--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
@@ -1022,7 +1022,8 @@ div.admonition {
   background-color: var(--pst-color-on-surface);
 }
 
-.output_area.rendered_html {
+/* Select only divisions that contain a dataframe, with enough specificity to override pydata css */
+div.nboutput div.output_area.rendered_html.docutils.container:has(table.dataframe) {
   background-color: transparent;
 }
 

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
@@ -290,6 +290,10 @@ tr:nth-child(even) {
   background-color: var(--pst-color-table-hover);
 }
 
+td {
+  color: var(--pst-color-text-base)
+}
+
 /*
 ###############
 Table-centered 
@@ -1016,6 +1020,10 @@ div.versionchanged {
 .admonition,
 div.admonition {
   background-color: var(--pst-color-on-surface);
+}
+
+.output_area.rendered_html {
+  background-color: transparent;
 }
 
 /*

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/breadcrumbs.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/breadcrumbs.css
@@ -1,7 +1,7 @@
 /* Provided by the Sphinx base theme template at build time,
 styles exclusively for the ansys-sphinx-theme classes. */
 
-@import "ansys_sphinx_theme.css";
+@import "ansys-sphinx-theme.css";
 
 /*
 ############

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/breadcrumbs.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/breadcrumbs.css
@@ -1,7 +1,7 @@
 /* Provided by the Sphinx base theme template at build time,
 styles exclusively for the ansys-sphinx-theme classes. */
 
-@import "ansys-sphinx-theme.css";
+@import "ansys_sphinx_theme.css";
 
 /*
 ############


### PR DESCRIPTION
Fix #281 

Explicitly specifies the font color in tabular cells, so that it changes correctly between light and dark themes. Also overrides the output div background color for cells that contain dataframes to transparent. Use of the `:has()` selector is currently not supported in Firefox - https://caniuse.com/css-has. I think we should still use it though, given that support will probably be added soon, and the use of `:has()` stops the changed css impacting other rendered html in a cell which may not be dark mode-aware.

Before:

![image](https://github.com/ansys/ansys-sphinx-theme/assets/6451062/132a8566-6c60-4e31-8cbb-13ad602e47e3)

After (Edge):

![image](https://github.com/ansys/ansys-sphinx-theme/assets/6451062/0a8b7b70-68d6-49c2-8f73-7b3e1c10362b)

After (Firefox):

![image](https://github.com/ansys/ansys-sphinx-theme/assets/6451062/b775ac79-9edd-46b0-8a8d-812ffe4b529f)
