### PR TITLE
fix: unicode char for exceptions

### DIFF
--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/_templates/autoapi/python/module.rst
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/_templates/autoapi/python/module.rst
@@ -174,7 +174,7 @@ Summary
 {% endif %}
 
 {% if visible_exceptions %}
-{{ toctree_from_objects_list(visible_exceptions, "") }}
+{{ toctree_from_objects_list(visible_exceptions, "🗲") }}
 {% endif %}
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
Fixes the unicode symbol used for exceptions when using sphinx-autoapi templates. This should be patched released into 0.11.1.