### PR TITLE
Render full doc string for classes when using autoapi

### DIFF
--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/_templates/autoapi/python/class.rst
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/_templates/autoapi/python/class.rst
@@ -10,7 +10,7 @@
 
           {% for obj in objects_list %}
           * - :py:attr:`~{{ obj.name }}`
-            - {{ obj.summary }}
+            - {{ obj.docstring }}
           {% endfor %}
 {%- endmacro %}
 
@@ -137,7 +137,7 @@ Overview
 {% endif %}
 
 {% if visible_attributes %}
-    {{ tab_item_from_objects_list(visible_attributes, "Attributes") }}      
+    {{ tab_item_from_objects_list(visible_attributes, "Attributes") }}
 {% endif %}
 
 {% if visible_static_methods %}


### PR DESCRIPTION
fixes #321 
This fix should allow users to use [autoapi_python_class_content](https://sphinx-autoapi.readthedocs.io/en/latest/reference/config.html#confval-autoapi_python_class_content) to control the verbosity of the class description.