### PR TITLE
fix: examples indentation

### DIFF
--- a/doc/source/examples/index.rst
+++ b/doc/source/examples/index.rst
@@ -10,15 +10,15 @@ This show how the different extensions get rendered in ansys-sphinx-theme. This 
          :link: sphinx-design
          :link-type: ref
 
-            Examples of the sphinx design rendered using the `ansys-sphinx-theme`.
+         Examples of the sphinx design rendered using the `ansys-sphinx-theme`.
 
    .. grid-item::
       .. card:: Table
          :link: table
          :link-type: ref
 
-            Examples of tables with JavaScript and RST rendered using the `ansys-sphinx-theme`.
-            It also recommends improving documentation with RST.
+         Examples of tables with JavaScript and RST rendered using the `ansys-sphinx-theme`.
+         It also recommends improving documentation with RST.
 
 
 .. toctree::

--- a/doc/source/examples/sphinx-design.rst
+++ b/doc/source/examples/sphinx-design.rst
@@ -14,11 +14,11 @@ please refer `sphinx design <https://sphinx-design.readthedocs.io/en/latest/inde
     {{ title[0].upper() }}{{ title[1:] }}
     {{ '~' * (title | length) }}
 
-        .. literalinclude:: sphinx_examples/{{ filename }}
-           :language: rst
+    .. literalinclude:: sphinx_examples/{{ filename }}
+       :language: rst
         
     This directive renders as follows:
 
-        .. include:: sphinx_examples/{{ filename }}
+    .. include:: sphinx_examples/{{ filename }}
 
     {% endfor %}

--- a/tox.ini
+++ b/tox.ini
@@ -43,4 +43,4 @@ commands =
 description = Check if documentation generates properly
 extras = doc
 commands =
-    sphinx-build -d "{toxworkdir}/doc_doctree" doc/source "{toxworkdir}/doc_out" --color -vW -bhtml
+    sphinx-build doc/source "{toxinidir}/doc/_build/html" --color -vW -bhtml


### PR DESCRIPTION
This pull-request fixes the indentation of the `Examples` section. As an example, consider:

**Before**
![Screenshot 2024-01-31 at 07-40-57 Examples — Ansys Sphinx Theme](https://github.com/ansys/ansys-sphinx-theme/assets/28702884/a03f7298-637d-40b3-883b-45c0648e7624)

**After**
![Screenshot 2024-01-31 at 07-41-14 Examples — Ansys Sphinx Theme](https://github.com/ansys/ansys-sphinx-theme/assets/28702884/030374a4-e840-4508-a747-2ac08c278145)

Same applies for the examples in the "sphinx-design.rst" page.