### PR TITLE
feat: add default pygment themes friendly (light) and monokai (dark)

### DIFF
--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
@@ -527,45 +527,6 @@ a > code.download {
 }
 
 /*
-#####################
-Sphinx gallery output
-#####################
-*/
-.sphx-glr-script-out .highlight pre {
-  background-color: var(--pst-color-codecell) !important;
-  color: var(--pst-color-codeout);
-}
-
-.prev-next-area a p.prev-next-title {
-  color: var(--pst-color-link);
-  font-weight: 600;
-  font-size: 1.1em;
-}
-
-.highlight .s1,
-.s2,
-.kc {
-  color: var(--pst-color-code-s1) !important;
-}
-
-html[data-theme="dark"] .highlight .kn {
-  color: #e18fff;
-  font-weight: normal;
-}
-
-.highlight .c1 {
-  color: var(--pst-color-code-c1);
-}
-
-html[data-theme="dark"] .highlight .n {
-  color: #b3d7ff;
-}
-
-html[data-theme="dark"] .highlight .nn {
-  color: #43d69d;
-  text-decoration: none;
-}
-/*
 ###############
 Dropdown button
 ###############

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/theme.conf
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/theme.conf
@@ -1,6 +1,5 @@
 [theme]
 inherit = pydata_sphinx_theme
-pygments_style = friendly
 
 [options]
 contact_mail =
@@ -15,3 +14,5 @@ switcher =
 use_meilisearch =
 article_header_start = breadcrumbs.html
 footer_end = theme-version.html
+pygment_light_style = friendly
+pygment_dark_style = monokai


### PR DESCRIPTION
Fixes #340 by adding default light and dark themes.

I am more than happy to continue the discussion in this thread. It may be possible that UI/UX can raise concerns about these.

What is true is that the contrast is better:

- Content: white on black (dark) and black on white (light)
- **We can improve docstrings and comments (not very readable)**: gray on black (dark) light blue on white (light)




Old dark             |  New dark
:-------------------------:|:-------------------------:
![Screenshot 2024-02-02 at 10-59-50 Getting started — Ansys Sphinx Theme](https://github.com/ansys/ansys-sphinx-theme/assets/28702884/6ff5175f-f59b-4af7-9641-9647f2589db8)  |  ![Screenshot 2024-02-02 at 10-55-14 Getting started — Ansys Sphinx Theme](https://github.com/ansys/ansys-sphinx-theme/assets/28702884/e8c16b93-f919-4542-901e-dfa8c0a4aa79)

Old light             |  New light
:-------------------------:|:-------------------------:
![Screenshot 2024-02-02 at 10-59-36 Getting started — Ansys Sphinx Theme](https://github.com/ansys/ansys-sphinx-theme/assets/28702884/53117678-aee9-4598-95e4-6bbb21bd2cc7)  |  ![Screenshot 2024-02-02 at 10-55-32 Getting started — Ansys Sphinx Theme](https://github.com/ansys/ansys-sphinx-theme/assets/28702884/cecee449-5460-4bf3-bbd9-0056072cc6e2)





