### PR TITLE
fix: color for topic directive

### DIFF
--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
@@ -1073,6 +1073,10 @@ div.nboutput
   background-color: transparent;
 }
 
+aside.topic > p {
+  color: var(--pst-color-text-base) !important;
+}
+
 /*
 ############
 Border lines


### PR DESCRIPTION
Fixes #342. Uses the right color for the selected theme:

![Screenshot 2024-02-12 at 14-51-41 Ansys Sphinx Theme documentation 0 14 dev0 — Ansys Sphinx Theme](https://github.com/ansys/ansys-sphinx-theme/assets/28702884/793d6d89-ce67-4189-9283-e0a4ac50e091)

![Screenshot 2024-02-12 at 14-51-59 Ansys Sphinx Theme documentation 0 14 dev0 — Ansys Sphinx Theme](https://github.com/ansys/ansys-sphinx-theme/assets/28702884/b7f7a7bf-ec87-4de5-b9e9-5baa030f62c0)
