### PR TITLE
feat: update templates for sphinx-autoapi==3.1.0a2

### DIFF
--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/_templates/autoapi/python/class.rst
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/_templates/autoapi/python/class.rst
@@ -18,14 +18,14 @@
 
 {% if obj.display %}
 
-{% if render_in_single_page and obj["type"] in render_in_single_page %}
+{% if own_page_types and obj["type"] in own_page_types %}
 {{ obj.short_name }}
 {{"=" * obj.name|length }}
 {% endif %}
 
 .. py:{{ obj["type"] }}:: {{ obj["short_name"] }}{% if obj["args"] %}({{ obj["args"] }}){% endif %}
 
-{% if render_in_single_page and obj["type"] in render_in_single_page %}
+{% if own_page_types and obj["type"] in own_page_types %}
    :canonical: {{ obj["obj"]["full_name"] }}
 {% endif %}
 
@@ -113,7 +113,7 @@ Bases: {% for base in obj.bases %}{{ base|link_objs }}{% if not loop.last %}, {%
 
 {% if class_objects %}
 
-{% if render_in_single_page and obj["type"] in render_in_single_page %}
+{% if own_page_types and obj["type"] in own_page_types %}
 Overview
 --------
 .. py:currentmodule:: {{ obj.short_name }}

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/_templates/autoapi/python/module.rst
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/_templates/autoapi/python/module.rst
@@ -173,7 +173,7 @@ Summary
 {% endblock %}
 
 {% block class %}
-{% if render_in_single_page and "class" in render_in_single_page %}
+{% if own_page_types and "class" in own_page_types %}
 {% if visible_interfaces %}
 {{ toctree_from_objects_list(visible_interfaces, "🝆") }}
 {% endif %}
@@ -193,13 +193,13 @@ Summary
 {% endblock %}
 
 {% block functions %}
-{% if render_in_single_page and visible_functions and "function" in render_in_single_page %}
+{% if own_page_types and visible_functions and "function" in own_page_types %}
 {{ toctree_from_objects_list(visible_functions, "𝑓(x)") }}
 {% endif %}
 {% endblock %}
 
 {% block constants %}
-{% if render_in_single_page and visible_constants and "constant" in render_in_single_page %}
+{% if own_page_types and visible_constants and "constant" in own_page_types %}
 {{ toctree_from_objects_list(visible_constants, "π") }}
 {% endif %}
 {% endblock %}
@@ -225,9 +225,9 @@ Description
 {% if module_objects_in_this_page %}
 {% set visible_objects_in_this_page = [] %}
 
-{% if render_in_single_page %}
+{% if own_page_types %}
 {% for obj in module_objects_in_this_page %}
-{% if obj.type not in render_in_single_page %}
+{% if obj.type not in own_page_types %}
 {% set _ = visible_objects_in_this_page.append(obj) %}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
Includes the new templates for ``sphinx-autoapi==3.1.0.a2``. These new templates need to be added in a new minor release since they introduce breaking changes.