### PR TITLE
fix: Update ``autoapi`` style to for disabling ``prename`` display.

### DIFF
--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
@@ -1161,3 +1161,9 @@ a:visited:hover {
 .bd-sidebar-primary {
   padding: 0.5rem;
 }
+
+/* Auto-api prename */
+
+.sig-prename.descclassname {
+  display: none;
+}

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
@@ -1162,7 +1162,11 @@ a:visited:hover {
   padding: 0.5rem;
 }
 
-/* Auto-api prename */
+/* Do not display object domain namespace when documenting objects.
+
+   Example: class ansys.module.foo.Foo.method -> method
+
+  */
 
 .sig-prename.descclassname {
   display: none;


### PR DESCRIPTION

Corrected display issue where function and property prefixes inside a class were improperly shown, e.g., `FooObject` --> `bar_property` displayed as `FooObject.bar_property` in the `FooObject` class instead of `bar_property`. This PR disables prefix display to maintain consistency with the function name only.