### PR TITLE
Update options.rst

### DIFF
--- a/doc/source/user_guide/options.rst
+++ b/doc/source/user_guide/options.rst
@@ -2,21 +2,20 @@
 
 HTML theme options
 ==================
-In the ``conf.py`` file for Sphinx, you can use the ``html_theme_options`` dictionary
-to customize the Ansys Sphinx theme.
+
+In the Sphinx configuration (``conf.py``) file in the ``doc`` directory, you can use the
+``html_theme_options`` dictionary to customize the Ansys Sphinx theme.
 
 Show breadcrumbs
 ----------------
-Breadcrumbs make navigation easier. While breadcrumbs are hidden by default,
-you can add ``"show_breadcrumbs": True`` to the ``html_theme_options`` dictionary
-to show them.
 
-If you want to add additional *root* breadcrumbs, such as to the Ansys
-documentation homepage, you add them to the ``html_theme_options`` dictionary as a
-list of tuples with the ``"additional_breadcrumbs"`` key. The tuples are of the
-form ``("Link text", "url")``.
+Showing breadcrumbs at the top of your documentation pages makes navigation easier.
+Breadcrumbs are shown by setting ``"show_breadcrumbs": True``. To add additional
+*root* breadcrumbs, ``"additional_breadcrumbs"`` is set to a list of tuples in
+this form: ``("Link text", "url")``.
 
-For example:
+This ``html_theme_options`` dictionary show breadcrumbs, including a root breadcrumb
+for the documentation landing page for the Ansys repository:
 
 .. code:: python
 
@@ -25,46 +24,51 @@ For example:
        "show_prev_next": False,
        "show_breadcrumbs": True,
        "additional_breadcrumbs": [
-           ("Ansys", "https://www.ansys.com/"),
+           ("PyAnsys", "https://docs.pyansys.com/"),
        ],
    }
 
-When you are on the documentation's homepage, the breadcrumb shows the homepage
-title. Because Sphinx cannot access this title from other documentation pages,
-you must use ``html_short_title`` to specify the display text for this breadcrumb.
+When you are on the landing page for your documentation, the breadcrumb shows the title for this
+page. However, Sphinx cannot access this title from other documentation pages. Thus, after
+``html_theme_options`` dictionary, you must set ``html_short_title``to the display text to
+use for this breadcrumb.
 
-To ensure a consistent user experience, ensure that the ``html_short_title``
-(or optionally ``html_title`` if ``html_short_title`` is not used) is set
-to the same value as the title for the main ``index.rst`` page:
+To ensure a consistent user experience, always set the ``html_short_title``
+(or optionally ``html_title`` if ``html_short_title`` is not used) to the library name.
+
+For example, in the ``conf.py`` file for the Ansys Sphinx Theme, this line is added
+after the ``html_theme_options`` dictionary:
 
 .. code:: python
 
    html_short_title = html_title = "Ansys Sphinx Theme"
 
-If you want to title for the main ``index.rst`` file to show the package version,
+If you want the title for your documentation's main ``index.rst`` file to show the version,
 include ``|version|`` in the title:
 
 .. code:: python
 
    html_short_title = html_title = "Ansys Sphinx Theme |version|"
 
-Customize icons
----------------
+
+Add and hide icons in the navigation bar
+----------------------------------------
+
 The navigation bar shows two icons on the right by default. The first is for
 switching between light and dark modes. The second is for going to the library's
 GitHub repository.
 
-- For comprehensive information on customizing icons, see
-  `Configure icon links <https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/header-links.html#add-custom-attributes-to-icon-links>`_
-  in the *PyData Theme* documentation.
-- For comprehensive information on `Font Awesome <https://fontawesome.com/>`_, an icon
-  library and toolkit, see its `documentation <https://fontawesome.com/v6/docs>`_,
-  particularly `How To Add Icons <https://fontawesome.com/v6/docs/web/add-icons/how-to>`_.
+- For comprehensive information on adding custom link behavior, see
+  `Add custom attributes to icon links <https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/header-links.html#add-custom-attributes-to-icon-links>`_
+  in the PyData Theme documentation.
+- For comprehensive information on how to use Font Awesome to add icons, see `How To Add Icons <https://fontawesome.com/v6/docs/web/add-icons/how-to>`_
+  in the Font Awesome documentation.
 
-The following sections explain how you can add icons and hide icons.
+The following sections explain how to add icons and hide icons.
 
 Add icons
 ~~~~~~~~~
+
 In the ``conf.py`` file, the ``html_theme_options`` dictionary has a child ``icon_links``
 dictionary. To add icons to the navigation bar, add them to the ``icon_links``
 dictionary. For each icon to add, specify its ``name``, the associated ``url``,
@@ -83,8 +87,9 @@ This example adds an icon for sending an email:
 
 Hide icons
 ~~~~~~~~~~
+
 To hide icons so that they do not show in the navigation bar, add their names
-to the ``hidden_icons`` list:
+to the ``hidden_icons`` dictionary:
 
 .. code-block:: pycon
 
@@ -94,7 +99,7 @@ to the ``hidden_icons`` list:
     }
 
 
-If you want to hide all icons, use the ``show_icons`` boolean variable:
+If you want to hide all icons, use the ``show_icons`` Boolean variable:
 
 .. code-block:: pycon
 
@@ -106,33 +111,32 @@ If you want to hide all icons, use the ``show_icons`` boolean variable:
 Use MeiliSearch
 ----------------
 
-MeiliSearch is an open-source search engine that allows developers to 
+MeiliSearch is an open source search engine that allows developers to 
 easily integrate search functionality into their applications.
 
-To use MeiliSearch in your Sphinx project, you can add a child 
-dictionary called ``use_meilisearch`` to the ``html_theme_options``
-dictionary in the ``conf.py`` file. 
+To use MeiliSearch in your documentation, in the ``conf.py`` file,
+a child dictionary named ``use_meilisearch``is added to the ``html_theme_options``
+dictionary. 
 
-This dictionary should contain the following keys:
+This dictionary contains these keys, in the order given:
 
-#. ``host``: The host name of your MeiliSearch instance. It is hosted at
-    https://backend.search.pyansys.com on port 7700 (default).
-    You can set this to an environment variable using 
-    ``os.getenv()`` for added security. If no value is provided, the default
-    public host for PyAnsys is used.
+#. ``host``: Host name of your MeiliSearch instance. If no value is provided,
+   the default public host for PyAnsys is used: ``https://backend.search.pyansys.com``
+   on port ``7700``. If added security is needed, you can use the ``os.getenv()`` function
+   to set the instance using an environment variable.
 
-#. ``api_key``: The API key for your MeiliSearch instance.
-   You can also set this to an environment variable using ``os.getenv()``. If no
-   value is provided, the default public API key for PyAnsys is used.
+#. ``api_key``: API key for your MeiliSearch instance. If no value is provided,
+   the default public API key for PyAnsys is used. If added security is needed,
+   you can use the ``os.getenv()`` function to set the key using an environment
+   variable. 
 
-#. ``index_uids``: A dictionary that provides a mapping between the unique
-   identifier (UID) of an index and its 
-   corresponding user-friendly name. Each key-value pair in the dictionary 
-   represents an index, with the key being the index UID and the value
-   being the index name. The index UID points to an index on the server.
+#. ``index_uids``: Dictionary that provides the mapping between the unique
+   identifier (UID) of an index and its corresponding user-friendly name.
+   Each key-value pair in the dictionary represents an index, with the key
+   being the index UID and the value being the index name. The index UID
+   points to an index on the server.
 
-
-Here is an example configuration for using MeiliSearch in the ``conf.py`` file:
+Here is an example of how to configure MeiliSearch for use in the ``conf.py`` file:
 
 .. code-block:: python
 
@@ -142,15 +146,16 @@ Here is an example configuration for using MeiliSearch in the ``conf.py`` file:
         "host": os.getenv("MEILISEARCH_HOST_NAME", ""),
         "api_key": os.getenv("MEILISEARCH_API_KEY", ""),
         "index_uids": {
-            "index-uid of current project": "index name to be displayed",
-            "another-index-uid": "index name to be displayed",
+            "index-uid of current project": "index name to display",
+            "another-index-uid": "index name to display",
         },
     }
 
-If your project features multiple documentation versions, it's crucial to adapt the ``index_uids``
-mapping to accommodate different versions. 
-To ensure seamless search integration across versions,
-use the following format to dynamically generate version-specific index ``UIDs``:
+
+If your project features multiple documentation versions, it's crucial to adapt the
+``index_uids`` mapping to accommodate different versions. To ensure seamless search
+integration across versions, use the following format to dynamically generate
+version-specific index ``UIDs``:
 
 .. code-block:: python
 
@@ -164,8 +169,8 @@ use the following format to dynamically generate version-specific index ``UIDs``
     }
 
 
-Here is the example configuration of using MeiliSearch in 
-``conf.py`` file of ``ansys-sphinx-theme``:
+Here is an example configuration of how to configure MeiliSearch in the ``conf.py`` file
+for the Ansys Sphinx Theme:
 
 .. code-block:: python
 
@@ -180,48 +185,53 @@ Here is the example configuration of using MeiliSearch in
         },
     }
 
-With these options set, your Sphinx project can use MeiliSearch 
-to provide search functionality for your documentation.
+
+With these options set, MeiliSearch is available for performing searches of
+your documentation.
 
 .. note::
 
-    If you do not set the "use_meilisearch" option,
-    ``ansys-sphinx-theme`` uses the default search functionality 
+    If you do not set the ``use_meilisearch`` dictionary, the
+    Ansys Sphinx Theme uses the default search functionality 
     inherited from the PyData Sphinx Theme.
 
 Cheat sheets
 ------------
 
-The ``cheatsheet`` HTML theme option can be used to enable a cheat sheet in the Ansys Sphinx theme.
+If a cheat sheet has been created for your PyAnsys library, you can show a thumbnail
+image of it in the left navigation pane of one or more sections of your documentation.
 
-To enable a cheatsheet, in the ``conf.py`` file for your PyAnsys
-library, you can add a child dictionary named ``cheatsheet`` to
-the ``html_theme_options`` dictionary. 
+In the ``html_theme_options`` dictionary, you add a child dictionary named ``cheatsheet`` 
+that contain these keys, in the order given:
 
-This dictionary should contain these keys, in the order given:
-
-#. ``url``: URL of the cheat sheet for downloading.
+#. ``url``: URL of the cheat sheet.
 #. ``title``: Title of the cheat sheet.
-#. ``thumbnail``: Thumbnail image for the cheat sheet.
-#. ``needs_download``: Whether to download the cheat sheet locally during the build. The default is ``False``, in which case the cheat sheet is accessed directly from the provided URL. If ``True``, the cheat sheet is downloaded to the ``_build/html/_static/`` directory. 
-#. ``pages``: List of pages to include in the cheat sheet (optional). If no list is provided, the cheat sheet includes the index page of the documentation.
+#. ``thumbnail``: URL of the thumbnail image for the cheat sheet.
+#. ``needs_download``: Whether to download the cheat sheet locally during the documentation build.
+   The default is ``False``, in which case the cheat sheet is accessed directly from the provided URL.
+   If ``True``, the cheat sheet is downloaded to the ``_build/html/_static/`` directory and accessed
+   from here. 
+#. ``pages``: List of names for the reStructuredText (RST) files to show the cheat sheet on. If no list
+   is provided, the cheat sheet is shown in the left navigation pane of the main ``index.rst`` file.
+
+Here is an example of how to add the ``cheatsheet`` dictionary to the `html_theme_options`` dictionary:
 
 .. code-block:: python
 
     html_theme_options = (
         {
             "cheatsheet": {
-                "url": "<your cheat sheet URL>",
-                "title": "<title of your cheat sheet>",
-                "thumbnail": "<image URL>",
-                "needs_download": True,  # True if you want to download the cheatsheet locally in the ``_build/html/_static/`` directory.
-                "pages": "<list of pages to include the cheat sheet on>",  # Optional
+                "url": "<URL of the cheat sheet>",
+                "title": "<title of the cheat sheet>",
+                "thumbnail": "<URL of the thumbnail image>",
+                "needs_download": True,  # True if you want to download and access the cheat sheet locally
+                "pages": "<list of names for the pages to include the cheat sheet on>",  # Optional
             },
         },
     )
 
-Here is an example configuration of using cheatsheet in 
-``conf.py`` file of ``PyMAPDL``:
+Here is an example of how to show a thumbnail of a PyMAPDL cheat sheet in the left navigation pane of its
+main ``index.rst`` file and the ``learning.rst`` file in its "Getting started" section:
 
  .. code-block:: python
 
@@ -229,7 +239,7 @@ Here is an example configuration of using cheatsheet in
         {
             "cheatsheet": {
                 "url": "https://cheatsheets.docs.pyansys.com/pymapdl_cheat_sheet.pdf",
-                "title": "PyMAPDL cheatsheet",
+                "title": "PyMAPDL cheat sheet",
                 "thumbnail": "https://cheatsheets.docs.pyansys.com/pymapdl_cheat_sheet.png",
                 "needs_download": True,
                 "pages": ["index", "getting_started/learning"],
@@ -239,10 +249,10 @@ Here is an example configuration of using cheatsheet in
 
 .. note:: 
 
-    if you set the "needs_download" option, you should provide the "html_static_path" option 
-    in the ``conf.py`` file to specify the location of the cheat sheet.
+    If you set ``"needs_download": True", you should provide the ``html_static_path`` option 
+    in the ``conf.py`` file to specify the location for downloading the cheat sheet to.
 
-    for example, if you need to download cheat sheet in the ``_build/html/_static/`` directory,
+    For example, if you want to download the cheat sheet to the ``_build/html/_static/`` directory,
     you should add the following line in the ``conf.py`` file:
 
     .. code-block:: pycon


### PR DESCRIPTION
@Revathyvenugopal162 I wanted to update this page of the Ansys Sphinx theme, especially to always make cheat sheet two words (except for the actual option name). I thought you could have more than one cheat sheet shown on a page and that you demoed this. However, I don't see a way to do this. Is there a new option not yet documented?