### PR TITLE
fix:  sphinx design card font size

### DIFF
--- a/doc/changelog.d/393.fixed.md
+++ b/doc/changelog.d/393.fixed.md
@@ -1,0 +1,1 @@
+fix:  sphinx design card font size

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
@@ -199,7 +199,6 @@ span.highlighted {
   color: var(--pst-color-inline-code);
   font-family: var(--pst-font-family-monospace);
   font-weight: 500;
-  font-size: medium;
 }
 
 code.literal {

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
@@ -199,7 +199,7 @@ span.highlighted {
   color: var(--pst-color-inline-code);
   font-family: var(--pst-font-family-monospace);
   font-weight: 500;
-  font-size: 87.5%;
+  font-size: medium;
 }
 
 code.literal {
@@ -873,7 +873,6 @@ blockquote {
 }
 .sd-sphinx-override,
 .sd-sphinx-override * {
-  font-size: medium;
   flex: auto;
 }
 
@@ -927,11 +926,6 @@ blockquote {
 .sd-card .sd-card-text {
   font-family: var(--pst-font-family-base) !important;
   background-color: var(--pst-color-background) !important;
-}
-
-/* hide the file name from card with clickable link footer in sphinx design */
-.sd-hide-link-text {
-  display: none;
 }
 
 .bd-content .sd-card .sd-card-header {


### PR DESCRIPTION
fix #392 

In the Sphinx design, the `sd-hide-link-text` class had a font size of 0. When we were overriding the size of the card, the entire size got overridden. I changed the size back to normal, and hopefully, this will work. relevant code here: [GitHub link](https://github.com/executablebooks/sphinx-design/blob/a3bdfa3742c25a7261a8301dfbb2a09e9700d325/style/_button.scss#L91).
tested locally 

