### PR TITLE
fix: move the version switcher to left navigation bar

### DIFF
--- a/doc/changelog.d/400.fixed.md
+++ b/doc/changelog.d/400.fixed.md
@@ -1,0 +1,1 @@
+fix: move the version switcher to left navigation bar

--- a/src/ansys_sphinx_theme/__init__.py
+++ b/src/ansys_sphinx_theme/__init__.py
@@ -169,7 +169,10 @@ def setup_default_html_theme_options(app):
     # Place all switchers and icons at the end of the navigation bar
     if app.config.html_theme_options.get("switcher"):
         app.config.html_theme_options.setdefault(
-            "navbar_end", ["version-switcher", "theme-switcher", "navbar-icon-links"]
+            "navbar_end", ["theme-switcher", "navbar-icon-links"]
+        )
+        app.config.html_theme_options.setdefault(
+            "navbar_center", ["version-switcher", "navbar-nav"]
         )
     app.config.html_theme_options.setdefault("collapse_navigation", True)
     app.config.html_theme_options.setdefault("navigation_with_keys", True)


### PR DESCRIPTION
![image](https://github.com/ansys/ansys-sphinx-theme/assets/104772255/af806172-7d09-4746-af32-519ad20a44b9)
