### PR TITLE
fix: sidebar borders and overflow

### DIFF
--- a/doc/changelog.d/427.fixed.md
+++ b/doc/changelog.d/427.fixed.md
@@ -1,0 +1,1 @@
+fix: sidebar borders and overflow

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/pydata-sphinx-theme-custom.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/pydata-sphinx-theme-custom.css
@@ -13,6 +13,12 @@
 .bd-sidebar-secondary {
   max-height: calc(100vh - var(--pst-header-height) - 1vh);
   line-height: var(--ast-global-line-height);
+  border: none;
+  overflow: hidden;
+}
+
+.sidebar-secondary-item {
+  border: none;
 }
 
 nav.bd-links p.bd-links__title,


### PR DESCRIPTION
Small continuation of https://github.com/ansys/ansys-sphinx-theme/pull/411. Ensures that no borders and scroll bars are displayed in any of the sidebars. Matches the style proposed in this comment https://github.com/ansys/ansys-sphinx-theme/issues/403#issuecomment-2179532890