### PR TITLE
fix: sphinx card `box shadow` on focus

### DIFF
--- a/doc/changelog.d/439.fixed.md
+++ b/doc/changelog.d/439.fixed.md
@@ -1,0 +1,1 @@
+fix: sphinx card `box shadow` on focus

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/sphinx-design.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/sphinx-design.css
@@ -239,6 +239,7 @@ details.sd-dropdown summary.sd-card-header + div.sd-summary-content {
   box-shadow: var(--ast-box-shadow-hover) !important;
 }
 
-.sd-hide-link-text {
-  display: none;
+.sd-hide-link-text:focus {
+  outline: none;
+  box-shadow: none;
 }


### PR DESCRIPTION
## Before
![image](https://github.com/user-attachments/assets/ac402682-9f81-40a2-8fa7-348455e6bf9b)

## Now
![image](https://github.com/user-attachments/assets/65dd403b-efc8-41b5-abdb-13b687b2a311)
