### PR TITLE
fix: search bar style for dark theme, icons links

### DIFF
--- a/doc/changelog.d/442.fixed.md
+++ b/doc/changelog.d/442.fixed.md
@@ -1,1 +1,1 @@
-fix: search bar style for dark theme
+fix: search bar style for dark theme, icons links

--- a/doc/source/user-guide/configuration.rst
+++ b/doc/source/user-guide/configuration.rst
@@ -57,7 +57,7 @@ To use the logo in both dark and light modes, add the following code to the``htm
 .. note::
 
     If you use the ``logo`` option, make sure to remove the ``html_logo`` option from the ``conf.py`` file.
-    ``logo`` will override the ``html_logo`` option and display the specified logo.
+    ``logo`` option overrides the ``html_logo`` option and display the specified logo.
 
 You can also add a custom logo by specifying the path to the logo file as specified in `pydata-sphinx-theme <pydata_logo_>`_.
 

--- a/doc/source/user-guide/configuration.rst
+++ b/doc/source/user-guide/configuration.rst
@@ -54,6 +54,11 @@ To use the logo in both dark and light modes, add the following code to the``htm
              "logo": "no_logo",
          }
 
+.. note::
+
+    If you use the ``logo`` option, make sure to remove the ``html_logo`` option from the ``conf.py`` file.
+    ``logo`` will override the ``html_logo`` option and display the specified logo.
+
 You can also add a custom logo by specifying the path to the logo file as specified in `pydata-sphinx-theme <pydata_logo_>`_.
 
 For example:
@@ -66,6 +71,7 @@ For example:
            "image_dark": "_static/logo-dark.png",
        }
    }
+
 
 ``favicon``
 ~~~~~~~~~~~

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys-sphinx-theme-variable.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys-sphinx-theme-variable.css
@@ -218,6 +218,7 @@ html[data-theme="light"] {
   --ast-search-bar-enable-text: #686868;
   --ast-suggestion-header-background: #d9d9d9;
   --ast-catagory-header-text: #353535;
+  --ast-catagory-suggestion-text: #8e8e8e;
   --ast-suggestion-text-color: #000000;
 
   /**
@@ -372,6 +373,7 @@ html[data-theme="dark"] {
   --ast-search-bar-enable-text: #d3d3d3;
   --ast-suggestion-header-background: #3d3d3d;
   --ast-catagory-header-text: #ececec;
+  --ast-catagory-suggestion-text: #686868;
   --ast-suggestion-text-color: #ffffff;
 
   /**

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/meilisearch.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/meilisearch.css
@@ -126,10 +126,16 @@ div[data-ds-theme] .meilisearch-autocomplete .docs-searchbar-suggestion {
 div[data-ds-theme]
   .meilisearch-autocomplete
   .docs-searchbar-suggestion--highlight {
-  color: var(--pst-color-info) !important;
+  color: var(--ast-suggestion-text-color) !important;
   font-weight: 900;
   background: transparent;
   padding: 0 0.05em;
+}
+
+.meilisearch-autocomplete .docs-searchbar-suggestion--text {
+  color: var(--ast-catagory-suggestion-text);
+  font-size: 12px;
+  line-height: var(--ast-global-line-height);
 }
 
 div[data-ds-theme]

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/pydata-sphinx-theme-custom.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/pydata-sphinx-theme-custom.css
@@ -192,6 +192,15 @@ a.nav-link.pst-navbar-icon:active {
   font-weight: bold;
 }
 
+ul.navbar-icon-links {
+  column-gap: 10px;
+}
+
+.bd-header .navbar-header-items__center,
+.bd-header .navbar-header-items__end {
+  column-gap: 10px;
+}
+
 /*
 * dropdown button after 5 sections
 */


### PR DESCRIPTION
continuation of #438

![image](https://github.com/user-attachments/assets/833f1a6f-27dc-4b50-a838-77adf25a3520)

![image](https://github.com/user-attachments/assets/4442d0d7-0da5-495c-9a84-b1373badec9a)

## column gap b/w icons in the navigation end
![image](https://github.com/user-attachments/assets/d2afa76c-701a-48b9-b694-a09c390af117)
![image](https://github.com/user-attachments/assets/3f50a6a9-d8e1-4fc7-ac81-88afc49ba860)



