### PR TITLE
fix: minor style changes

### DIFF
--- a/doc/changelog.d/452.fixed.md
+++ b/doc/changelog.d/452.fixed.md
@@ -1,0 +1,1 @@
+fix: minor style changes

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/pydata-sphinx-theme-custom.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/pydata-sphinx-theme-custom.css
@@ -706,3 +706,16 @@ button.btn.version-switcher__button:hover {
   filter: box-shadow(var(--ast-box-shadow-active));
   border: none;
 }
+
+/**
+* Article content (_article.scss)
+*/
+
+.bd-main .bd-content .bd-article-container {
+  padding: 8px;
+  width: 1000px;
+}
+
+.bd-sidebar-primary {
+  width: 20%;
+}

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/sphinx-design.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/sphinx-design.css
@@ -53,8 +53,8 @@ blockquote {
 
 .bd-content details.sd-dropdown {
   color: var(--ast-dropdown-text-color);
-  max-width: 500px;
-  width: 100%;
+  width: fit-content;
+  min-width: 400px;
 }
 
 .bd-content details.sd-dropdown summary.sd-summary-title {

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/table-custom.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/table-custom.css
@@ -48,7 +48,8 @@ th {
 */
 
 tr {
-  line-height: 56px;
+  line-height: var(--ast-global-line-height);
+  height: 56px;
   color: var(--ast-color-table-cell-text);
 }
 


### PR DESCRIPTION
## table with larger content
#### before
![image](https://github.com/user-attachments/assets/39c22afe-b39c-48b3-910e-81b51bf606ea)
### after
![image](https://github.com/user-attachments/assets/2bfd8be8-e679-4f19-9bbc-43a9a28d4c02)

## dropdown with large codes, 
fit the content based on the content length, keep 400px as min width

https://github.com/user-attachments/assets/71d82269-a8da-45d7-9ee3-23b635a4b50c

## primary sidebar width
### before
![image](https://github.com/user-attachments/assets/864d2d8e-4044-4f03-8973-279816fa5a65)
### after
![image](https://github.com/user-attachments/assets/ceac1476-013b-44db-89d0-c1c2e2e5e414)


