### PR TITLE
fix: the scrollbar on sidebar

### DIFF
--- a/doc/changelog.d/474.fixed.md
+++ b/doc/changelog.d/474.fixed.md
@@ -1,0 +1,1 @@
+fix: the scrollbar on sidebar

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/pydata-sphinx-theme-custom.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/pydata-sphinx-theme-custom.css
@@ -14,7 +14,12 @@
   max-height: calc(100vh - var(--pst-header-height) - 1vh);
   line-height: var(--ast-global-line-height);
   border: none;
-  overflow: hidden;
+  overflow: auto;
+}
+
+.bd-sidebar-primary .sidebar-primary-items__end {
+  margin-bottom: unset;
+  margin-top: unset;
 }
 
 .sidebar-secondary-item {


### PR DESCRIPTION
The sidebar scrolls only appear if there is sidebar content is more than the page height. fix #468 
![image](https://github.com/user-attachments/assets/fa97ca07-af6c-4c68-81e9-ffefa96fce4b)
![scroll](https://github.com/user-attachments/assets/e68670b9-5544-41a8-a98d-0e91016a2abd)
