### PR TITLE
fix: admonitions styles for ``topic`` admonition

### DIFF
--- a/doc/changelog.d/477.fixed.md
+++ b/doc/changelog.d/477.fixed.md
@@ -1,0 +1,1 @@
+fix: admonitions styles for ``topic`` admonition

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/pydata-sphinx-theme-custom.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/pydata-sphinx-theme-custom.css
@@ -502,6 +502,7 @@ span.versionmodified:before {
   height: var(--ast-admonition-icon-height);
   width: var(--ast-admonition-icon-width);
   left: 0px;
+  color: var(--ast-color-text);
 }
 
 span.versionmodified:before {
@@ -638,6 +639,12 @@ div.versionchanged {
   border-color: var(--ast-admonition-neutral-border);
 }
 
+aside.topic p,
+div.topic p,
+div.topic.contents p,
+nav.contents p {
+  color: var(--ast-admonition-neutral-icon) !important;
+}
 /**
 * Dropdown _header.scss
 */


### PR DESCRIPTION
fix #475 
after
![image](https://github.com/user-attachments/assets/5f214b4b-7f65-4eb3-9246-7e68ca0b63c9)
## admonitions icon in dark mode
before
![image](https://github.com/user-attachments/assets/e920ba7d-60c0-4a57-9b3e-78a7606c2d28)
After
![image](https://github.com/user-attachments/assets/197cc5be-8f1e-4686-ba4e-1ca8178b0d95)
