### PR TITLE
maint: update tooling, cleanup and drop python 3.9

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -97,7 +97,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
         should-release:
           - ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags') }}
         exclude:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,29 +1,16 @@
 repos:
-- repo: https://github.com/psf/black
-  rev: 24.8.0
-  hooks:
-  - id: black
 
-- repo: https://github.com/pycqa/isort
-  rev: 5.13.2
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.6.2
   hooks:
-  - id: isort
-
-- repo: https://github.com/PyCQA/flake8
-  rev: 7.1.1
-  hooks:
-  - id: flake8
+    - id: ruff
+      args: [--fix]
+    - id: ruff-format
 
 - repo: https://github.com/codespell-project/codespell
   rev: v2.3.0
   hooks:
   - id: codespell
-
-- repo: https://github.com/pycqa/pydocstyle
-  rev: 6.3.0
-  hooks:
-  - id: pydocstyle
-    additional_dependencies: [toml]
 
 - repo: https://github.com/pre-commit/mirrors-prettier
   rev: 'v4.0.0-alpha.8'
@@ -41,17 +28,9 @@ repos:
 
 # this validates our github workflow files
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.29.1
+  rev: 0.29.2
   hooks:
     - id: check-github-workflows
-
-
-- repo: https://github.com/adamchainz/blacken-docs
-  rev: 1.18.0
-  hooks:
-  - id: blacken-docs
-    additional_dependencies: [black==24.4.2]
-    exclude: 'src/ansys_sphinx_theme/theme/ansys_sphinx_theme/_templates/'
 
 - repo: https://github.com/ansys/pre-commit-hooks
   rev: v0.4.3

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Ansys Sphinx theme
    :target: https://github.com/ansys
    :alt: Ansys
 
-.. |python| image:: https://img.shields.io/badge/Python-%3E%3D3.9-blue
+.. |python| image:: https://img.shields.io/pypi/pyversions/ansys_sphinx_theme?logo=pypi
    :target: https://pypi.org/project/ansys-sphinx-theme/
    :alt: Python
 
@@ -55,47 +55,24 @@ If you are new to using Sphinx, see `Sphinx Getting Started
 
 Documentation and issues
 ~~~~~~~~~~~~~~~~~~~~~~~~
-In addition to installation information, the
-`Ansys Sphinx theme documentation <https://sphinxdocs.ansys.com>`_
-provides information on how you can customize the theme. Because
-this documentation is created using this theme, viewing it is
-an easy way to preview the theme itself.
+Documentation for the latest stabe release of Ansys Sphinx theme is hosted at
+`Ansys Sphinx Theme documentation <https://sphinxdocs.ansys.com>`_.
+
+The documentation has these sections:
+
+- `Getting started <https://sphinxdocs.ansys.com/version/stable/getting_started.html>`_ : Learn
+  how to install the theme and use it in your Sphinx project.
+- `User guide <https://sphinxdocs.ansys.com/version/stable/user_guide.html>`_ : Learn how to
+  customize the theme and use its features.
+- `Examples <https://sphinxdocs.ansys.com/version/stable/examples.html>`_ : See examples of
+  Sphinx components and how it renders with the Ansys Sphinx theme.
+- `Release notes <https://sphinxdocs.ansys.com/version/stable/changelog.html>`_ : See the
+  changes in each release of the theme.
 
 On the `Issues page <https://github.com/ansys/ansys-sphinx-theme/issues>`_
 for this repository, you can create issues to submit questions, report bugs,
 and request new features. To reach the PyAnsys support team, email
 `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
-
-Getting started
-~~~~~~~~~~~~~~~
-Install the ``ansys-sphinx-theme`` package with:
-
-.. code::
-
-   python -m pip install ansys-sphinx-theme
-
-Modify your Sphinx ``conf.py`` file to use ``html_theme =
-'ansys_sphinx_theme'``.
-
-Development and contributions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-If you want to contribute to the PyAnsys Sphinx theme, install
-the ``ansys-sphinx-theme`` package in development mode with::
-
-   git clone https://github.com/ansys/ansys-sphinx-theme.git
-   python -m pip install -U pip tox
-   tox -e style,doc
-
-To simplify checks, this repository uses `pre-commit <https://pre-commit.com/>`_.
-You can optionally install and use this tool. For more information, see its
-`installation <https://pre-commit.com/#install>`_ and `usage
-<https://pre-commit.com/#usage>`_ documentation.
-
-Before contributing to a PyAnsys library, see
-`Contributing <https://dev.docs.pyansys.com//how-to/contributing.html>`_
-in the *PyAnsys Developer's Guide* for overall guidance, paying particular
-attention to `How-to <https://dev.docs.pyansys.com//how-to/index.html>`_ for
-guidelines and best practices.
 
 License
 ~~~~~~~

--- a/doc/changelog.d/480.dependencies.md
+++ b/doc/changelog.d/480.dependencies.md
@@ -1,0 +1,1 @@
+build(deps): bump pygithub from 2.3.0 to 2.4.0

--- a/doc/changelog.d/482.dependencies.md
+++ b/doc/changelog.d/482.dependencies.md
@@ -1,0 +1,1 @@
+build(deps): bump notebook from 7.2.1 to 7.2.2

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -234,7 +234,7 @@ def download_and_process_files(example_links: List[str]) -> List[str]:
     for link in example_links:
         file_name = link.split("/")[-1]
         file_path = str((EXAMPLE_PATH / file_name).absolute())
-        with Path.open(file_path, "wb") as f:
+        with open(file_path, "wb") as f:  # noqa: PTH123
             response = requests.get(link)
             content = response.content.decode()
             lines = content.splitlines()

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -146,7 +146,7 @@ exclude_patterns = [
     "examples/gallery-examples/*.ipynb",
 ]
 rst_epilog = ""
-with open("links.rst") as f:
+with Path.open(THIS_PATH / "links.rst", "r") as f:
     rst_epilog += f.read()
 
 sphinx_gallery_conf = {
@@ -234,7 +234,7 @@ def download_and_process_files(example_links: List[str]) -> List[str]:
     for link in example_links:
         file_name = link.split("/")[-1]
         file_path = str((EXAMPLE_PATH / file_name).absolute())
-        with open(file_path, "wb") as f:
+        with Path.open(file_path, "wb") as f:
             response = requests.get(link)
             content = response.content.decode()
             lines = content.splitlines()

--- a/doc/source/examples/nbsphinx/jupyter-notebook.ipynb
+++ b/doc/source/examples/nbsphinx/jupyter-notebook.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import pyvista as pv\n",
     "\n",
-    "pv.set_jupyter_backend('html')\n",
+    "pv.set_jupyter_backend(\"html\")\n",
     "\n",
     "sphere = pv.Sphere()\n",
     "sphere.plot()"
@@ -36,8 +36,8 @@
    "outputs": [],
    "source": [
     "plotter = pv.Plotter(notebook=True)\n",
-    "plotter.add_mesh(sphere, color='white', show_edges=True)\n",
-    "plotter.title = '3D Sphere Visualization'\n",
+    "plotter.add_mesh(sphere, color=\"white\", show_edges=True)\n",
+    "plotter.title = \"3D Sphere Visualization\"\n",
     "plotter.show()"
    ]
   },
@@ -55,7 +55,8 @@
    "outputs": [],
    "source": [
     "from IPython.display import Math\n",
-    "eq = Math(r'\\int\\limits_{-\\infty}^\\infty f(x) \\delta(x - x_0) dx = f(x_0)')\n",
+    "\n",
+    "eq = Math(r\"\\int\\limits_{-\\infty}^\\infty f(x) \\delta(x - x_0) dx = f(x_0)\")\n",
     "eq"
    ]
   },
@@ -66,7 +67,8 @@
    "outputs": [],
    "source": [
     "from IPython.display import Latex\n",
-    "Latex(r'This is a \\LaTeX{} equation: $a^2 + b^2 = c^2$')"
+    "\n",
+    "Latex(r\"This is a \\LaTeX{} equation: $a^2 + b^2 = c^2$\")"
    ]
   },
   {
@@ -107,9 +109,9 @@
     "\n",
     "# Create a dictionary of data\n",
     "data = {\n",
-    "    'A': [True, False, True, False],\n",
-    "    'B': [False, True, False, True],\n",
-    "    'C': [True, True, False, False],\n",
+    "    \"A\": [True, False, True, False],\n",
+    "    \"B\": [False, True, False, True],\n",
+    "    \"C\": [True, True, False, False],\n",
     "}\n",
     "\n",
     "# Create DataFrame from the dictionary\n",

--- a/doc/source/examples/snippet.py
+++ b/doc/source/examples/snippet.py
@@ -48,7 +48,7 @@ def func(arg1, arg2):
 
     Examples
     --------
-    >>> func(1, 'foo')
+    >>> func(1, "foo")
     True
 
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ doc = [
     "numpydoc==1.8.0",
     "pandas==2.2.2",
     "Pillow>=9.0",
-    "PyGitHub==2.3.0",
+    "PyGitHub==2.4.0",
     "pyvista[jupyter]==0.44.1",
     "requests==2.32.3",
     "Sphinx==8.0.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ autoapi = [
 ]
 doc = [
     "jupytext==1.16.4",
-    "notebook==7.2.1",
+    "notebook==7.2.2",
     "nbsphinx==0.9.5",
     "numpydoc==1.8.0",
     "pandas==2.2.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "ansys-sphinx-theme"
 version = "1.1.dev0"
 description = "A theme devised by ANSYS, Inc. for Sphinx documentation."
 readme = "README.rst"
-requires-python = ">=3.9,<4"
+requires-python = ">=3.10,<4"
 license = {file = "LICENSE"}
 authors = [{ name = "ANSYS, Inc.", email = "pyansys.core@ansys.com" }]
 maintainers = [{ name = "ANSYS, Inc.", email = "pyansys.core@ansys.com" }]
@@ -18,7 +18,9 @@ classifiers = [
     "Framework :: Sphinx :: Theme",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
     "Sphinx>=4.2.0",
@@ -146,8 +148,6 @@ showcontent = true
 directory = "miscellaneous"
 name = "Miscellaneous"
 showcontent = true
-
-
 
 [[tool.towncrier.type]]
 directory = "documentation"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,14 +74,39 @@ Source = "https://github.com/ansys/ansys-sphinx-theme"
 Tracker = "https://github.com/ansys/ansys-sphinx-theme/issues"
 Documentation = "https://sphinxdocs.ansys.com/"
 
-[tool.black]
+[tool.ruff]
 line-length = 100
+fix = true
 
-[tool.isort]
-profile = "black"
-force_sort_within_sections = true
-line_length = 100
-src_paths = ["doc", "src"]
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle, see https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
+    "D",    # pydocstyle, see https://docs.astral.sh/ruff/rules/#pydocstyle-d
+    "F",    # pyflakes, see https://docs.astral.sh/ruff/rules/#pyflakes-f
+    "I",    # isort, see https://docs.astral.sh/ruff/rules/#isort-i
+    "N",    # pep8-naming, see https://docs.astral.sh/ruff/rules/#pep8-naming-n
+    "PTH",  # flake8-use-pathlib, https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth
+    "TD",   # flake8-todos, https://docs.astral.sh/ruff/rules/#flake8-todos-td
+]
+ignore = [
+    "TD002", # Missing author in TODOs comment
+]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]
+"doc/source/examples/sphinx-gallery/sphinx-gallery.py" = ["D205", "E402", "D400"]
+"src/ansys_sphinx_theme/extension/linkcode.py" = ["E501"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
+[tool.ruff.lint.isort]
+combine-as-imports = true
+force-sort-within-sections = true
 
 [tool.coverage.run]
 source = ["src"]

--- a/src/ansys_sphinx_theme/__init__.py
+++ b/src/ansys_sphinx_theme/__init__.py
@@ -20,7 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""This is the ansys-sphinx-theme module."""
+"""Module for the Ansys Sphinx theme."""
+
 import logging
 import os
 import pathlib
@@ -341,9 +342,9 @@ def replace_html_tag(app, exception):
 
     file_names = list(api_path.rglob("*.html"))
     for file_name in file_names:
-        with open(api_dir / file_name, "r", encoding="utf-8") as file:
+        with pathlib.Path.open(api_dir / file_name, "r", encoding="utf-8") as file:
             content = file.read()
-        with open(api_dir / file_name, "w", encoding="utf-8") as file:
+        with pathlib.Path.open(api_dir / file_name, "w", encoding="utf-8") as file:
             modified_content = content.replace("&lt;", "<").replace("&gt;", ">")
             file.write(modified_content)
 
@@ -472,7 +473,7 @@ def build_quarto_cheatsheet(app: Sphinx):
     output_dir_path = pathlib.Path(app.outdir) / output_dir
     try:
         # Add the cheatsheet to the Quarto project
-        result = subprocess.run(
+        subprocess.run(
             [
                 "quarto",
                 "add",
@@ -485,7 +486,7 @@ def build_quarto_cheatsheet(app: Sphinx):
         )
 
         # Render the cheatsheet
-        render_result = subprocess.run(
+        subprocess.run(
             [
                 "quarto",
                 "render",
@@ -501,7 +502,7 @@ def build_quarto_cheatsheet(app: Sphinx):
         )
 
         # Remove the cheatsheet from the Quarto project
-        remove_extension = subprocess.run(
+        subprocess.run(
             ["quarto", "remove", "ansys/cheat_sheet", "--no-prompt"],
             cwd=file_path,
             capture_output=True,

--- a/src/ansys_sphinx_theme/examples/sample_func.py
+++ b/src/ansys_sphinx_theme/examples/sample_func.py
@@ -48,7 +48,7 @@ def func(arg1, arg2):
 
     Examples
     --------
-    >>> func(1, 'foo')
+    >>> func(1, "foo")
     True
 
     """

--- a/src/ansys_sphinx_theme/examples/samples.py
+++ b/src/ansys_sphinx_theme/examples/samples.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 """Sample classes and functions for ansys-sphinx-theme."""
+
 from math import sqrt
 
 
@@ -48,7 +49,7 @@ class ExampleClass:
     An example of how to initialize this class should be given.
 
     >>> from ansys_sphinx_theme import samples
-    >>> example = samples.ExampleClass('mystr', ['apple', 'orange'], 3)
+    >>> example = samples.ExampleClass("mystr", ["apple", "orange"], 3)
 
     """
 
@@ -88,7 +89,7 @@ class ExampleClass:
         >>> example.readwrite_property
         "readwrite_property"
 
-        >>> example.readwrite_property = 'hello world'
+        >>> example.readwrite_property = "hello world"
         >>> example.readwrite_property
         'hello world'
 
@@ -121,7 +122,7 @@ class ExampleClass:
 
         Examples
         --------
-        >>> example.example_method('foo', 'bar')
+        >>> example.example_method("foo", "bar")
         True
 
         """

--- a/src/ansys_sphinx_theme/examples/type_hint_example.py
+++ b/src/ansys_sphinx_theme/examples/type_hint_example.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 """Module containing an example function using type hinting."""
+
 from typing import Union
 
 
@@ -46,7 +47,7 @@ def type_hint_func(param1: int = 1, param2: str = "test", param3: Union[int, flo
 
     Examples
     --------
-    >>> func(1, 'foo', 1)
+    >>> func(1, "foo", 1)
     True
 
     """

--- a/src/ansys_sphinx_theme/extension/autoapi.py
+++ b/src/ansys_sphinx_theme/extension/autoapi.py
@@ -82,6 +82,7 @@ def add_autoapi_theme_option(app: Sphinx) -> None:
         autoapi.get("directory", "src/ansys"), start=str(app.confdir / "conf.py")
     )
     app.config["autoapi_dirs"] = [relative_autoapi_dir]
+    print(f"AutoAPI directories: {app.config['autoapi_dirs']}")
 
 
 def setup(app: Sphinx) -> Dict[str, Any]:

--- a/src/ansys_sphinx_theme/extension/autoapi.py
+++ b/src/ansys_sphinx_theme/extension/autoapi.py
@@ -29,6 +29,14 @@ from sphinx.application import Sphinx
 
 from ansys_sphinx_theme import __version__, get_autoapi_templates_dir_relative_path
 
+AUTOAPI_OPTIONS = [
+    "members",
+    "undoc-members",
+    "show-inheritance",
+    "show-module-summary",
+    "special-members",
+]
+
 
 def add_autoapi_theme_option(app: Sphinx) -> None:
     """Add the autoapi template path to the theme options.
@@ -41,14 +49,6 @@ def add_autoapi_theme_option(app: Sphinx) -> None:
     autoapi = app.config.html_theme_options.get("ansys_sphinx_theme_autoapi", {})
     if not autoapi:
         return
-
-    AUTOAPI_OPTIONS = [
-        "members",
-        "undoc-members",
-        "show-inheritance",
-        "show-module-summary",
-        "special-members",
-    ]
     autoapi_template_dir = autoapi.get("templates", "")
     autoapi_project_name = autoapi.get("project", "")
 

--- a/src/ansys_sphinx_theme/extension/linkcode.py
+++ b/src/ansys_sphinx_theme/extension/linkcode.py
@@ -141,7 +141,6 @@ def sphinx_linkcode_resolve(
             return None
         return None
 
-    # make fn in pathlib
     fn = Path(fn).resolve().relative_to(Path(__file__).resolve().parent)
     fn_components = fn.parts
 

--- a/src/ansys_sphinx_theme/extension/linkcode.py
+++ b/src/ansys_sphinx_theme/extension/linkcode.py
@@ -21,10 +21,10 @@
 # SOFTWARE.
 
 """A module containing the an extension for creating links to original source code files."""
+
 import inspect
 import logging
-import os
-import os.path as op
+from pathlib import Path
 import sys
 
 from docutils import nodes
@@ -141,8 +141,9 @@ def sphinx_linkcode_resolve(
             return None
         return None
 
-    fn = op.relpath(fn, start=os.path.dirname(os.path.abspath(__file__)))
-    fn_components = op.normpath(fn).split(os.sep)
+    # make fn in pathlib
+    fn = Path(fn).resolve().relative_to(Path(__file__).resolve().parent)
+    fn_components = fn.parts
 
     if not source_path:
         module = modname.split(".")[0]
@@ -198,7 +199,7 @@ def link_code(app: Sphinx, doctree: Node):
     for link resolution.
 
     The ``linkcode`` extension in this version has been adapted from the original
-    `Sphinx linkcode extension <https://github.com/sphinx-doc/sphinx/blob/main/sphinx/ext/linkcode.py>`_. # noqa: E501
+    `Sphinx linkcode extension <https://github.com/sphinx-doc/sphinx/blob/main/sphinx/ext/linkcode.py>`_.  # noqa: E501
     This adaptation involves modifying the original code and functionality from the Sphinx library.
     """
     env = app.builder.env

--- a/src/ansys_sphinx_theme/latex/__init__.py
+++ b/src/ansys_sphinx_theme/latex/__init__.py
@@ -20,14 +20,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""This module creates the title page for a LaTeX pdf."""
+"""Module creates the title page for a LaTeX pdf."""
+
 from datetime import datetime
-import os
 from pathlib import Path
 
 import jinja2
 
-LATEX_SUBPKG = Path(os.path.dirname(os.path.realpath(__file__)))
+LATEX_SUBPKG = Path(__file__).resolve().parent
 COVER_TEX = LATEX_SUBPKG / "cover.tex"
 PAGE_404 = LATEX_SUBPKG / "404.html"
 

--- a/tox.ini
+++ b/tox.ini
@@ -42,4 +42,4 @@ setenv =
     links: BUILDER = linkcheck
     html: BUILDER = html
 commands =
-    sphinx-build -d "{toxworkdir}/doc_doctree" doc/source "{toxinidir}/doc/_build/{env:BUILDER}" --color -vW -b {env:BUILDER} -j auto
+    sphinx-build -d "{toxworkdir}/doc_doctree" doc/source "{toxinidir}/doc/_build/{env:BUILDER}" --color -v -b {env:BUILDER} -j auto -W --keep-going

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ setenv =
 passenv = *
 
 [testenv:code-style]
-description = Check source code compliance with project's code style
+description = check project code style
 skip_install = true
 deps =
     pre-commit
@@ -42,4 +42,4 @@ setenv =
     links: BUILDER = linkcheck
     html: BUILDER = html
 commands =
-    sphinx-build "{toxinidir}/doc/source" "{toxinidir}/doc/_build/{env:BUILDER}" --color -vW -b {env:BUILDER}
+    sphinx-build -d "{toxworkdir}/doc_doctree" doc/source "{toxinidir}/doc/_build/{env:BUILDER}" --color -vW -b {env:BUILDER} -j auto


### PR DESCRIPTION
### Changes in this PR

- **Pre-commit Hooks:** Replaced  with `ruff` for linting and formatting in favour of migrating ``sphinx-url`` extension.
- **README Cleanup:** Updated the README for better clarity and removed outdated content.
- **Python 3.9:** Dropped support for Python 3.9 as per the new compatibility guidelines.
- **Tox Configuration:** Modified `tox.ini` to align with the updated Python versions and tools.
