### PR TITLE
fix: the download in sphinx gallery

### DIFF
--- a/doc/changelog.d/490.fixed.md
+++ b/doc/changelog.d/490.fixed.md
@@ -1,0 +1,1 @@
+fix: the download in sphinx gallery

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/sphinx-gallery.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/sphinx-gallery.css
@@ -50,3 +50,17 @@ div.sphx-glr-download a {
   background-color: var(--ast-sphinx-gallery-download-background);
   color: var(--ast-sphinx-gallery-download-text);
 }
+
+div.sphx-glr-footer {
+  text-align: center;
+  display: flex;
+  gap: 10px;
+  align-content: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  flex-direction: row;
+}
+
+div.sphx-glr-download {
+  margin: 0px;
+}


### PR DESCRIPTION
continuation of #489 
Here the download buttons are misaligned https://sphinxdocs.ansys.com/version/dev/examples/gallery-examples/sphinx-gallery.html#render-a-table-in-markdown
This PR will fix the issue

# output
![image](https://github.com/user-attachments/assets/62a9bf89-78ed-47f2-acae-c7ecd13175e2)

