### PR TITLE
feat: add member_order to autoapi

### DIFF
--- a/doc/changelog.d/495.added.md
+++ b/doc/changelog.d/495.added.md
@@ -1,0 +1,1 @@
+feat: add member_order to autoapi

--- a/doc/source/user-guide/autoapi.rst
+++ b/doc/source/user-guide/autoapi.rst
@@ -29,6 +29,9 @@ and set the ``ansys_sphinx_theme_autoapi`` theme options in the ``html_theme_opt
   By default, this is set to ``False``.
 - ``package_depth``: The depth of the package. By default, this is set to ``3``. This is the ``namespace`` depth of the package.
   For example, if the package is ``ansys``, the depth is ``1``. If the package is ``ansys.foo``, the depth is ``2``.
+- ``member_order``: The order to document members. By default, this is set to ``bysource``. Other options include
+  ``alphabetical``, which orders members by their name (case sensitive), or ``groupwise``, which orders members by their type
+  and alphabetically.
 
 All these options can be set in the ``conf.py`` file of your Sphinx project.
 
@@ -54,6 +57,7 @@ All these options can be set in the ``conf.py`` file of your Sphinx project.
             "ignore": [],
             "add_toctree_entry": False,
             "package_depth": 3,
+            "member_order": "bysource",
         }
     }
 

--- a/src/ansys_sphinx_theme/extension/autoapi.py
+++ b/src/ansys_sphinx_theme/extension/autoapi.py
@@ -76,6 +76,7 @@ def add_autoapi_theme_option(app: Sphinx) -> None:
     app.config["autoapi_options"] = autoapi.get("options", AUTOAPI_OPTIONS)
     app.config["autoapi_ignore"] = autoapi.get("ignore", [])
     app.config["autoapi_add_toctree_entry"] = autoapi.get("add_toctree_entry", True)
+    app.config["autoapi_member_order"] = autoapi.get("member_order", "bysource")
 
     # HACK: The ``autoapi_dirs`` should be given as a relative path to the conf.py.
     relative_autoapi_dir = os.path.relpath(


### PR DESCRIPTION
The members are ordered by source rather than alphabetically, so this change should allow people to organize their documentation in alphabetical order if they want

autoapi_member_order: https://sphinx-autoapi.readthedocs.io/en/latest/reference/config.html#confval-autoapi_member_order
