### PR TITLE
fix: do not display captions for nbgallery

### DIFF
--- a/doc/changelog.d/503.fixed.md
+++ b/doc/changelog.d/503.fixed.md
@@ -1,1 +1,1 @@
-fix: do not diplay captions for nbgallery
+fix: do not display captions for nbgallery

--- a/doc/changelog.d/503.fixed.md
+++ b/doc/changelog.d/503.fixed.md
@@ -1,0 +1,1 @@
+fix: do not diplay captions for nbgallery

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/nbsphinx.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/nbsphinx.css
@@ -6,5 +6,5 @@
  * Do not display the caption paragraph in the body content for 'nbgallery'
  */
 .toctree-wrapper > p.caption {
-    display: none;
+  display: none;
 }

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/nbsphinx.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/nbsphinx.css
@@ -1,0 +1,10 @@
+/*
+ * Overrides the default CSS for https://nbsphinx.readthedocs.io/ extension.
+ */
+
+/*
+ * Do not display the caption paragraph in the body content for 'nbgallery'
+ */
+.toctree-wrapper > p.caption {
+    display: none;
+}


### PR DESCRIPTION
This pull-request removes the caption within the body content created by the `nbgallery` extension. The caption rendered within the sidebar is still present.