### PR TITLE
feat: adding custom vars directives

### DIFF
--- a/doc/changelog.d/523.added.md
+++ b/doc/changelog.d/523.added.md
@@ -1,1 +1,1 @@
-feat: adding custon vars directives
+feat: adding custom vars directives

--- a/doc/changelog.d/523.added.md
+++ b/doc/changelog.d/523.added.md
@@ -1,0 +1,1 @@
+feat: adding custon vars directives

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -9,7 +9,8 @@ from typing import List
 from github import Github
 import pyvista
 import requests
-import sphinx
+from sphinx.addnodes import document as doctree
+from sphinx.application import Sphinx as App
 from sphinx.builders.latex import LaTeXBuilder
 
 from ansys_sphinx_theme import (
@@ -27,7 +28,7 @@ THIS_PATH = Path(__file__).parent.resolve()
 EXAMPLE_PATH = (THIS_PATH / "examples" / "sphinx_examples").resolve()
 
 # To allow using 'helper' python file as a module
-sys.path.append(Path(__file__).parent)
+sys.path.append(str(Path(__file__).parent))
 
 # Project information
 project = "ansys_sphinx_theme"
@@ -273,11 +274,11 @@ jinja_contexts = {
 
 
 def remove_edit_this_page_if_directive(
-    app: sphinx.app,
+    app: App,
     pagename: str,
     templatename: str,
-    context: sphinx.context,
-    doctree: sphinx.doctree,
+    context: dict,
+    doctree: doctree,
     page_vars: dict,
 ):
     """Remove 'edit this page' button.
@@ -287,15 +288,15 @@ def remove_edit_this_page_if_directive(
 
     Parameters
     ----------
-    app : sphinx.app
+    app : sphinx.application.Sphinx
         Sphinx app
     pagename : str
         Page name
     templatename : str
         Template name
-    context : sphinx.context
+    context : dict
         Page context
-    doctree : sphinx.doctree
+    doctree : sphinx.addnodes.document
         Page doctree
     page_vars : dict
         Page variables
@@ -308,11 +309,11 @@ def remove_edit_this_page_if_directive(
 
 
 def remove_show_source_if_directive(
-    app: sphinx.app,
+    app: App,
     pagename: str,
     templatename: str,
-    context: sphinx.context,
-    doctree: sphinx.doctree,
+    context: dict,
+    doctree: doctree,
     page_vars: dict,
 ):
     """Remove the 'show_source' link.
@@ -322,15 +323,15 @@ def remove_show_source_if_directive(
 
     Parameters
     ----------
-    app : sphinx.app
+    app : sphinx.application.Sphinx
         Sphinx app
     pagename : str
         Page name
     templatename : str
         Template name
-    context : sphinx.context
+    context : dict
         Page context
-    doctree : sphinx.doctree
+    doctree : sphinx.addnodes.document
         Page doctree
     page_vars : dict
         Page variables
@@ -342,11 +343,11 @@ def remove_show_source_if_directive(
 
 
 def pre_build_page_html(
-    app: sphinx.app,
+    app: App,
     pagename: str,
     templatename: str,
-    context: sphinx.context,
-    doctree: sphinx.doctree,
+    context: dict,
+    doctree: doctree,
 ):
     """Apply hooks before building HTML.
 
@@ -354,15 +355,15 @@ def pre_build_page_html(
 
     Parameters
     ----------
-    app : sphinx.app
+    app : sphinx.application.Sphinx
         Sphinx app
     pagename : str
         Page name
     templatename : str
         Template name
-    context : sphinx.context
+    context : dict
         Page context
-    doctree : sphinx.doctree
+    doctree : sphinx.addnodes.document
         Page doctree
     """
     from helpers import get_page_vars
@@ -375,12 +376,12 @@ def pre_build_page_html(
     remove_show_source_if_directive(app, pagename, templatename, context, doctree, page_vars)
 
 
-def setup(app: sphinx):
+def setup(app: App):
     """Add custom configuration to sphinx app.
 
     Parameters
     ----------
-    app : sphinx.application.sphinx
+    app : sphinx.application.Sphinxlication.sphinx
         The Sphinx application.
     """
     from helpers import SetPageVariableDirective, add_custom_variables_to_context

--- a/doc/source/helpers.py
+++ b/doc/source/helpers.py
@@ -1,10 +1,11 @@
 """Helper classes and functions for documentation build."""
 
 from docutils.parsers.rst import Directive
-import sphinx
+from sphinx.addnodes import document as doctree
+from sphinx.application import Sphinx as App
 
 
-def get_page_vars(app: sphinx.app, pagename: str) -> dict:
+def get_page_vars(app: App, pagename: str) -> dict:
     """Get page variables.
 
     Get each page variables.
@@ -28,7 +29,7 @@ def get_page_vars(app: sphinx.app, pagename: str) -> dict:
         or not env.pages_vars
         or not env.pages_vars.get(pagename, None)
     ):
-        return
+        return {}
 
     return env.pages_vars[pagename]
 
@@ -77,11 +78,11 @@ class SetPageVariableDirective(Directive):
 
 
 def add_custom_variables_to_context(
-    app: sphinx.app,
+    app: App,
     pagename: str,
     templatename: str,
-    context: sphinx.context,
-    doctree: sphinx.doctree,
+    context: dict,
+    doctree: doctree,
 ) -> None:
     """Add customs variables to build context.
 
@@ -89,15 +90,15 @@ def add_custom_variables_to_context(
 
     Parameters
     ----------
-    app : Sphinx.app
+    app : sphinx.application.Sphinx
         Sphinx app.
     pagename : str
         Page name
     templatename : str
         Template page
-    context : Sphinx.context
+    context : dict
         Page context
-    doctree : Sphinx.doctree
+    doctree : sphinx.addnodes.document
         Page doctree
     """
     env = app.builder.env

--- a/doc/source/helpers.py
+++ b/doc/source/helpers.py
@@ -1,0 +1,109 @@
+"""Helper classes and functions for documentation build."""
+
+from docutils.parsers.rst import Directive
+import sphinx
+
+
+def get_page_vars(app: sphinx.app, pagename: str) -> dict:
+    """Get page variables.
+
+    Get each page variables.
+
+    Parameters
+    ----------
+    app : app
+        Sphinx app
+    pagename : str
+        Page name
+
+    Returns
+    -------
+    dict
+        Dictionary with variables as keys, and their values.
+    """
+    env = app.builder.env
+
+    if (
+        not hasattr(env, "pages_vars")
+        or not env.pages_vars
+        or not env.pages_vars.get(pagename, None)
+    ):
+        return
+
+    return env.pages_vars[pagename]
+
+
+class SetPageVariableDirective(Directive):
+    """Set page variables.
+
+    Set page variables.
+
+    Parameters
+    ----------
+    - variable: str
+    - value: str
+
+    Example
+
+    .. setpagevar:: my_key my_value
+
+    The key cannot have spaces.
+
+    .. setpagevar:: my_key my value
+
+    """
+
+    has_content = False
+    required_arguments = 2  # Variable name and value
+    optional_arguments = 0
+
+    def run(self):
+        """Run directive."""
+        var_name = self.arguments[0]
+        var_value = self.arguments[1]
+        env = self.state.document.settings.env
+
+        # Store the variable in the environment specific to each page
+        if not hasattr(env, "pages_vars"):
+            env.pages_vars = {}
+
+        # Store the variable for the current page (env.docname is the document name)
+        if env.docname not in env.pages_vars:
+            env.pages_vars[env.docname] = {}
+
+        env.pages_vars[env.docname][var_name] = var_value
+
+        return []
+
+
+def add_custom_variables_to_context(
+    app: sphinx.app,
+    pagename: str,
+    templatename: str,
+    context: sphinx.context,
+    doctree: sphinx.doctree,
+) -> None:
+    """Add customs variables to build context.
+
+    This is needed to be able to access the vars at the build stage.
+
+    Parameters
+    ----------
+    app : Sphinx.app
+        Sphinx app.
+    pagename : str
+        Page name
+    templatename : str
+        Template page
+    context : Sphinx.context
+        Page context
+    doctree : Sphinx.doctree
+        Page doctree
+    """
+    env = app.builder.env
+
+    # Check if there are page-specific variables stored by the directive
+    if hasattr(env, "pages_vars"):
+        if pagename in env.pages_vars:
+            # Add the stored variables to the context for this page
+            context.update(env.pages_vars[pagename])

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -8,6 +8,11 @@ This theme is specifically tailored for documentation related to Ansys projects
 helping to ensure consistency in its look and feel. Various useful extensions
 are included in the theme to make documentation more appealing and user-friendly.
 
+
+.. setpagevar:: hide_edit_page_button True
+
+.. setpagevar:: hide_show_source True
+
 .. grid:: 2
     :gutter: 2 2 3 4
 


### PR DESCRIPTION
Add the directive "setpagevar" which allow us to set page variables which can later be used during the HTML building process ("html-page-context").

Additionally, to prove/test the directive, I coded two functions, one to remove the "edit this page" button and another one for remove the "show source" button.


This directive and functionalities have not been implemented in the ansys-sphinx-theme, but I don't see why we should not use them here to, so all the libraries using the theme can benefit from it.


Future steps should aim to have something for processing each page HTML after it has been build.
I guess we will need to use 'build-finished' event, and parse each page with beautiful soup so we can add stuff (like attributes) to HTML elements. Later we can overwrite the HTML pages. 

This could allow us to get the same as https://github.com/ansys/pymapdl/pull/3449 which is quite specific to the intended use.

This is all doable... I'm just lacking of time.