### PR TITLE
fix: add default `enter` for search

### DIFF
--- a/doc/changelog.d/542.fixed.md
+++ b/doc/changelog.d/542.fixed.md
@@ -1,0 +1,1 @@
+fix: add default `enter` for search

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/js/fuse_search.js
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/js/fuse_search.js
@@ -111,12 +111,9 @@ require(["fuse"], function (Fuse) {
 
     switch (event.key) {
       case "Enter":
-        // event.preventDefault(); // Prevent form submission
         if (currentIndex >= 0 && currentIndex < resultItems.length) {
+          event.preventDefault(); // Prevent default enter action
           const href = resultItems[currentIndex].getAttribute("data-href");
-          navigateToHref(href);
-        } else if (resultItems.length > 0) {
-          const href = resultItems[0].getAttribute("data-href");
           navigateToHref(href);
         }
         break;

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/js/fuse_search.js
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/js/fuse_search.js
@@ -111,7 +111,7 @@ require(["fuse"], function (Fuse) {
 
     switch (event.key) {
       case "Enter":
-        event.preventDefault(); // Prevent form submission
+        // event.preventDefault(); // Prevent form submission
         if (currentIndex >= 0 && currentIndex < resultItems.length) {
           const href = resultItems[currentIndex].getAttribute("data-href");
           navigateToHref(href);


### PR DESCRIPTION
fix #539 

1. Pressing Enter without typing anything in the search bar will take you to the PyData search page.
2. Pressing Enter on any of the entries in the suggestion bar will take you to the corresponding anchor.
3. After typing a search query, if the suggestions aren't enough, pressing Enter will take you to the PyData search page.
