### PR TITLE
fix: padding for toctree entry in sidebar

### DIFF
--- a/doc/changelog.d/554.fixed.md
+++ b/doc/changelog.d/554.fixed.md
@@ -1,0 +1,1 @@
+fix: padding for toctree entry in sidebar

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/pydata-sphinx-theme-custom.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/pydata-sphinx-theme-custom.css
@@ -83,7 +83,7 @@ nav.bd-links li > a.current {
 
 .bd-sidebar-primary li.has-children .caption,
 .bd-sidebar-primary li.has-children > .reference {
-  padding: 4px 32px;
+  padding: 4px 24px;
 }
 
 nav.bd-links .current > a {


### PR DESCRIPTION
fix #543 
## before
![image](https://github.com/user-attachments/assets/73d91d42-8378-4e8c-a0b0-e95d4d769c19)

## After
![image](https://github.com/user-attachments/assets/e64291b9-5c3a-47ba-9ffe-030b6f176a88)
