### PR TITLE
fix: changelog action

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -45,11 +45,12 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: ansys/actions/doc-changelog@v8
-      with:
-        token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
-        bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
-        bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}
+      - uses: ansys/actions/doc-changelog@v8
+        if: ${{ github.event_name == 'pull_request '}}
+        with:
+          token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
+          bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
+          bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}
 
   code-style:
     name: Code style


### PR DESCRIPTION
This pull-request fixes the issues raise in <https://github.com/ansys/ansys-sphinx-theme/actions/runs/11459431277/job/31935828742>, where the ``doc-changelog`` action fails when trying to create a fragment outside of a pull-request.
