### PR TITLE
Enable 'show_prev_next' in the documented defaults

### DIFF
--- a/doc/changelog.d/580.documentation.md
+++ b/doc/changelog.d/580.documentation.md
@@ -1,0 +1,1 @@
+Enable 'show_prev_next' in the documented defaults

--- a/doc/source/user-guide/options.rst
+++ b/doc/source/user-guide/options.rst
@@ -21,7 +21,7 @@ for the documentation landing page for the Ansys repository:
 
    html_theme_options = {
        "github_url": "https://github.com/ansys/ansys-sphinx-theme",
-       "show_prev_next": False,
+       "show_prev_next": True,
        "show_breadcrumbs": True,
        "additional_breadcrumbs": [
            ("PyAnsys", "https://docs.pyansys.com/"),


### PR DESCRIPTION
Switch the default value of `show_prev_next` to True in the theme options documentation.

The reason for this change is that the prev / next buttons are useful for navigating the documentation, especially in narrow viewports.
In that case, the only other option to navigate is the hamburger menu, which the user may not be aware of.