### PR TITLE
Fix/remove broken references

### DIFF
--- a/src/ansys_sphinx_theme/__init__.py
+++ b/src/ansys_sphinx_theme/__init__.py
@@ -585,7 +585,9 @@ def setup(app: Sphinx) -> Dict:
     # Add default HTML configuration
     setup_default_html_theme_options(app)
 
-    update_search_config(app)
+    use_pyansys_search = app.config.html_theme_options.get("use_ansys_search", False)
+    if use_pyansys_search:
+        update_search_config(app)
 
     # Verify that the main CSS file exists
     if not CSS_PATH.exists():
@@ -604,7 +606,8 @@ def setup(app: Sphinx) -> Dict:
     app.connect("html-page-context", add_cheat_sheet)
     app.connect("html-page-context", add_search_option)
     app.connect("build-finished", replace_html_tag)
-    app.connect("build-finished", create_search_index)
+    if use_pyansys_search:
+        app.connect("build-finished", create_search_index)
     return {
         "version": __version__,
         "parallel_read_safe": True,

--- a/src/ansys_sphinx_theme/__init__.py
+++ b/src/ansys_sphinx_theme/__init__.py
@@ -27,6 +27,7 @@ import os
 import pathlib
 import subprocess
 from typing import Any, Dict
+import warnings
 
 from docutils import nodes
 from sphinx import addnodes
@@ -433,6 +434,28 @@ def add_cheat_sheet(
         context["sidebars"] = sidebar
 
 
+def add_search_option(
+    app: Sphinx, pagename: str, templatename: str, context: Dict[str, Any], doctree: nodes.document
+) -> None:
+    """Control the type of searching used.
+
+    Parameters
+    ----------
+    app : ~sphinx.application.Sphinx
+        Application instance for rendering the documentation.
+    pagename : str
+        Name of the current page.
+    templatename : str
+        Name of the template being used.
+    context : dict
+        Context dictionary for the page.
+    doctree : ~docutils.nodes.document
+        The doctree.
+    """
+    use_pyansys_search = app.config.html_theme_options.get("use_ansys_search", False)
+    context["use_ansys_search"] = use_pyansys_search
+
+
 def build_quarto_cheatsheet(app: Sphinx):
     """
     Build the Quarto cheatsheet.
@@ -533,8 +556,10 @@ def check_for_depreciated_theme_options(app: Sphinx):
     """
     theme_options = app.config.html_theme_options
     if "use_meilisearch" in theme_options:
-        raise DeprecationWarning(
-            "The 'use_meilisearch' option is deprecated. Remove the option from your configuration file."  # noqa: E501
+        warnings.warn(
+            "The 'use_meilisearch' option is deprecated. Remove the option "
+            "from your configuration file.",
+            DeprecationWarning,
         )
 
 
@@ -577,6 +602,7 @@ def setup(app: Sphinx) -> Dict:
     app.connect("html-page-context", update_footer_theme)
     app.connect("html-page-context", fix_edit_html_page_context)
     app.connect("html-page-context", add_cheat_sheet)
+    app.connect("html-page-context", add_search_option)
     app.connect("build-finished", replace_html_tag)
     app.connect("build-finished", create_search_index)
     return {

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/layout.html
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/layout.html
@@ -17,5 +17,7 @@
 
 {%- block content %}
   {{ super() }}
-  {%- include "components/ast-search-button.html" %}
+  {% if use_ansys_search %}
+    {%- include "components/ast-search-button.html" %}
+  {%  endif %}
 {%- endblock %}

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
@@ -1,8 +1,7 @@
 /* Provided by the Sphinx base theme template at build time */
 
 @import "../basic.css";
-@import "../sg_gallery.css";
-@import "ansys-sphinx-theme-variables.css";
+@import "ansys-sphinx-theme-variable.css";
 @import "pydata-sphinx-theme-custom.css";
 @import "breadcrumbs.css";
 @import "ast-search.css";

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/ansys_sphinx_theme.css
@@ -1,7 +1,5 @@
 /* Provided by the Sphinx base theme template at build time */
 
-@import "../basic.css";
-@import "ansys-sphinx-theme-variable.css";
 @import "pydata-sphinx-theme-custom.css";
 @import "breadcrumbs.css";
 @import "ast-search.css";

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/pydata-sphinx-theme-custom.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/pydata-sphinx-theme-custom.css
@@ -1,6 +1,5 @@
 /* Changes associated with the Ansys Sphinx Theme */
 /* for pydata-sphinx-theme */
-@import "../styles/pydata-sphinx-theme.css";
 @import "ansys-sphinx-theme-variable.css";
 
 /*

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/sphinx-design.css
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/css/sphinx-design.css
@@ -1,5 +1,3 @@
-@import "../design-style.4045f2051d55cab465a707391d5b2007.min.css";
-
 /**
 * sphinx design button
 */

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/theme.conf
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/theme.conf
@@ -18,3 +18,4 @@ cheatsheet =
 ansys_sphinx_theme_autoapi =
 logo =
 static_search =
+use_ansys_search = True


### PR DESCRIPTION
I decided to create a draft PR with some possible clean-up or improvements to the theme. I'm not an expert in this area though, and I don't know a lot of the history, so I don't know for sure if these are good changes or not. They're all broadly focused on trying to reduce the number of errors in the browser console. Not all of these only occur when opening the files directly, some occur even when hosted through github, see here https://jobqueue.grantami.docs.pyansys.com/version/dev/index.html.

Summary of the changes I've hacked together so far:

* Remove some `@import` statements from CSS files. As far as I can tell, these files are all imported separately in the HTML. The thing that got me looking in this area is the `@import "../sg_gallery.css";` statement, which fails if the sphinx-gallery extension isn't used
* Use a theme config entry to control whether `ast-search-button.html` is included in the document. If fuse-search isn't being used, this avoids running the javascript which causes errors when not running through a server. Also, the fuse-search.css doesn't seem to exist either.
  * This might be an alternative way of handling the fuse search vs sphinx search thing. I tried this out quickly with the v1.2.0 version of search.js and it sort of works, but on click the results disappear. Probably wouldn't be too much effort if that's the direction you wanted to go.
* Warn about meilisearch, instead of raising a warning. This causes an exception when building, when I think we actually want to be warning instead.

There are still lots of CORS errors when searching, which is strange because they don't occur when using the pydata sphinx theme directly. Some more digging might be able to fix this.

Given that a lot of this relates to using the theme for a closed-source project that should work when opening the files not via a web server, I'm happy to do the legwork in resolving these issues. I just want to make sure it's moving in a direction that everyone's comfortable with before I get too far down the line.