### PR TITLE
fix: rename the ``date`` to ``ast_build_date`` in js

### DIFF
--- a/doc/changelog.d/594.miscellaneous.md
+++ b/doc/changelog.d/594.miscellaneous.md
@@ -1,0 +1,1 @@
+fix: rename the ``date`` to ``ast_build_date`` in js

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/components/theme-version.html
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/components/theme-version.html
@@ -4,11 +4,11 @@
     >Ansys Sphinx Theme</a
   >
   {{ ansys_sphinx_theme_version }}.{% endtrans %} <br />Last updated on
-  <span id="date"></span>
+  <span id="ast_build_date"></span>
 </p>
 <script>
   var options = { day: "numeric", month: "long", year: "numeric" };
-  var lastModifiedDate = new Date(document.lastModified);
-  var date = lastModifiedDate.toLocaleDateString("en-US", options);
-  document.getElementById("date").innerHTML = date;
+  var ast_lastModifiedDate = new Date(document.lastModified);
+  var ast_build_date = lastModifiedDate.toLocaleDateString("en-US", options);
+  document.getElementById("ast_build_date").innerHTML = ast_build_date;
 </script>


### PR DESCRIPTION
## Before
![image](https://github.com/user-attachments/assets/faae984f-060e-481b-9468-eb3ff9e44ba7)

## After
![image](https://github.com/user-attachments/assets/8635a054-d083-4775-9d94-7c37d1d2a5bc)

The `Date class` or ``date module``, if referenced in the API documentation, had all its docstrings replaced with the build date due to a conflict with the date variable in JavaScript, which caused only the date to render in the documentation. In the PR, the date variable was renamed to `ast_build_date` to resolve this issue.. reported by @jorgepiloto 