### PR TITLE
fix: impose upper version for the pydata-sphinx-theme

### DIFF
--- a/doc/changelog.d/603.miscellaneous.md
+++ b/doc/changelog.d/603.miscellaneous.md
@@ -1,0 +1,1 @@
+fix: impose upper version for the pydata-sphinx-theme

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "Sphinx>=4.2.0",
-    "pydata-sphinx-theme>=0.15.4,<0.17",
+    "pydata-sphinx-theme>=0.15.4,<0.16",
     "Jinja2>=3.1.2",
     "importlib-metadata>=4.0",
     "pdf2image>=1.17.0",


### PR DESCRIPTION
Because of the current upper limit, we got affected by the latest release of pydata-sphinx-theme in the form of a small section in the right sidebar:

![image](https://github.com/user-attachments/assets/935e8847-7cf3-40a8-8983-45ca5f391c7b)

This should fix it, forcing dependabot to open a new pull-request for us to adapt.