### PR TITLE
fix: typo in autoapi template

### DIFF
--- a/doc/changelog.d/630.miscellaneous.md
+++ b/doc/changelog.d/630.miscellaneous.md
@@ -1,0 +1,1 @@
+fix: typo in autoapi template

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/_templates/autoapi/python/class.rst
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/_templates/autoapi/python/class.rst
@@ -19,15 +19,15 @@
 
 {# ----------------- Start macros definition for autosummary -----------------#}
 
-{% macro autosummary_section(title, members, member_name) -%}
+{% macro autosummary_section(title, members) -%}
 
 {{ title }}
 {{ "-" * title | length }}
 
 .. autoapisummary::
 
-    {% for member_name in members %}
-    {{ member_name.id }}
+    {% for member in members %}
+    {{ member.id }}
     {% endfor %}
 
 {%- endmacro %}
@@ -187,23 +187,23 @@ Import detail
         {% set visible_attributes = own_page_children|selectattr("type", "equalto", "attribute")|list %}
 
         {% if visible_attributes %}
-{{ autosummary_section("Attributes", visible_attributes, "attribute") }}
+{{ autosummary_section("Attributes", visible_attributes) }}
         {% endif %}
         {% set visible_exceptions = own_page_children|selectattr("type", "equalto", "exception")|list %}
 
         {% if visible_exceptions %}
-{{ autosummary_section("Exceptions", visible_exceptions, "exception") }}
+{{ autosummary_section("Exceptions", visible_exceptions) }}
         {% endif %}
         {% set visible_classes = own_page_children|selectattr("type", "equalto", "class")|list %}
 
         {% if visible_classes %}
-{{ autosummary_section("Classes", visible_classes, "klass") }}
+{{ autosummary_section("Classes", visible_classes) }}
 
         {% endif %}
         {% set visible_methods = own_page_children|selectattr("type", "equalto", "method")|list %}
 
         {% if visible_methods %}
-{{ autosummary_section("Methods", visible_methods, "method") }}
+{{ autosummary_section("Methods", visible_methods) }}
         {% endif %}
     {% endif %}
 

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/_templates/autoapi/python/class.rst
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/_templates/autoapi/python/class.rst
@@ -19,16 +19,16 @@
 
 {# ----------------- Start macros definition for autosummary -----------------#}
 
-{% macro render_autosummary_section(title, members) -%}
+{% macro autosummary_section(title, members, member_name) -%}
 
 {{ title }}
 {{ "-" * title | length }}
 
 .. autoapisummary::
 
-         {% for member in members %}
-    {{ member.id }}
-        {% endfor %}
+    {% for member_name in members %}
+    {{ member_name.id }}
+    {% endfor %}
 
 {%- endmacro %}
 {# ------------------ End macros definition for autosummary --------------- #}
@@ -187,23 +187,23 @@ Import detail
         {% set visible_attributes = own_page_children|selectattr("type", "equalto", "attribute")|list %}
 
         {% if visible_attributes %}
-{{ autosummary_section("Attributes", visible_attributes) }}
+{{ autosummary_section("Attributes", visible_attributes, "attribute") }}
         {% endif %}
         {% set visible_exceptions = own_page_children|selectattr("type", "equalto", "exception")|list %}
 
         {% if visible_exceptions %}
-{{ autosummary_section("Exceptions", visible_exceptions) }}
+{{ autosummary_section("Exceptions", visible_exceptions, "exception") }}
         {% endif %}
         {% set visible_classes = own_page_children|selectattr("type", "equalto", "class")|list %}
 
         {% if visible_classes %}
-{{ autosummary_section("Classes", visible_classes) }}
+{{ autosummary_section("Classes", visible_classes, "klass") }}
 
         {% endif %}
         {% set visible_methods = own_page_children|selectattr("type", "equalto", "method")|list %}
 
         {% if visible_methods %}
-{{ autosummary_section("Methods", visible_methods) }}
+{{ autosummary_section("Methods", visible_methods, "method") }}
         {% endif %}
     {% endif %}
 


### PR DESCRIPTION
Found this typo when there was a change in a library with a nested class using the template, which caused it to fail to render.

The macro was defined as `render_autosummary_template `and used in the function as `autosummary_template`, which caused the issue.