### PR TITLE
fix: remove flake8 configuration file

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,0 @@
-[flake8]
-exclude = _build
-select = W191, W291, W293, W391, E115, E117, E122, E124, E125, E225, E231, E301, E303, E501, F401, F403
-count = True
-max-complexity = 10
-max-line-length = 100
-statistics = True

--- a/doc/changelog.d/641.miscellaneous.md
+++ b/doc/changelog.d/641.miscellaneous.md
@@ -1,0 +1,1 @@
+fix: remove flake8 configuration file

--- a/doc/changelog.d/changelog_template.jinja
+++ b/doc/changelog.d/changelog_template.jinja
@@ -1,17 +1,22 @@
 {% if sections[""] %}
-{% for category, val in definitions.items() if category in sections[""] %}
 
-{{ definitions[category]['name'] }}
-{% set underline = '^' * definitions[category]['name']|length %}
-{{ underline }}
+.. tab-set::
+
+{%+ for category, val in definitions.items() if category in sections[""] %}
+
+  .. tab-item:: {{ definitions[category]['name'] }}
+
+    .. list-table::
+        :header-rows: 0
+        :widths: auto
 
 {% for text, values in sections[""][category].items() %}
-- {{ text }} {{ values|join(', ') }}
-{% endfor %}
+        * - {{ text }}
+          - {{ values|join(', ') }}
 
 {% endfor %}
+{% endfor %}
+
 {% else %}
 No significant changes.
-
-
 {% endif %}


### PR DESCRIPTION
This pull-request removes the configuration file for `.flake8`. We are fully supporting Ruff, so it makes no sense to keep this file around.