### PR TITLE
feat: Add Tox environment for documentation preview

### DIFF
--- a/doc/changelog.d/642.added.md
+++ b/doc/changelog.d/642.added.md
@@ -1,0 +1,1 @@
+feat: Add Tox environment for documentation preview

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -192,8 +192,7 @@ def extract_example_links(
     list
         List of example links.
     """
-    token = os.getenv("GITHUB_TOKEN")
-    g = Github(token)
+    g = Github()
     repo = g.get_repo(repo_fullname)
     contents = repo.get_contents(path_relative_to_root)
     if not isinstance(contents, list):

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -26,6 +26,7 @@ from ansys_sphinx_theme import (
 )
 
 THIS_PATH = Path(__file__).parent.resolve()
+PYANSYS_LIGHT_SQUARE = (THIS_PATH / "_static" / "pyansys_light_square.png").resolve()
 EXAMPLE_PATH = (THIS_PATH / "examples" / "sphinx_examples").resolve()
 
 # Project information
@@ -191,7 +192,8 @@ def extract_example_links(
     list
         List of example links.
     """
-    g = Github()
+    token = os.getenv("GITHUB_TOKEN")
+    g = Github(token)
     repo = g.get_repo(repo_fullname)
     contents = repo.get_contents(path_relative_to_root)
     if not isinstance(contents, list):
@@ -270,7 +272,7 @@ else:
         "download_all_examples": False,
         # Modules for which function level galleries are created.  In
         "image_scrapers": ("pyvista", "matplotlib"),
-        "default_thumb_file": "source/_static/pyansys_light_square.png",
+        "default_thumb_file": str(PYANSYS_LIGHT_SQUARE),
     }
 
     nbsphinx_prolog = """

--- a/doc/source/contribute/developer.rst
+++ b/doc/source/contribute/developer.rst
@@ -239,3 +239,9 @@ You can clean the build directory by running::
 
     # On Windows
     doc\make.bat clean
+
+.. Note::
+
+    Use ``tox -e doc-preview`` to build the documentation and open it in your
+    default browser. This command will also watch for changes in the source
+    files and rebuild the documentation automatically.

--- a/doc/source/contribute/developer.rst
+++ b/doc/source/contribute/developer.rst
@@ -242,6 +242,6 @@ You can clean the build directory by running::
 
 .. Note::
 
-    Use ``tox -e doc-preview`` to build the documentation and open it in your
+    Use ``tox -e doc-serve`` to build the documentation and open it in your
     default browser. This command will also watch for changes in the source
     files and rebuild the documentation automatically.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
     "name": "ansys_sphinx_theme",
     "repository": "https://github.com/ansys/ansys-sphinx-theme",
-
     "description": "",
     "main": "",
     "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "sphinx-theme-builder >= 0.2.0b2,<1",
+  "sphinx-theme-builder>=0.2.0b2,<1",
 ]
 build-backend = "sphinx_theme_builder"
 
@@ -62,6 +62,7 @@ doc = [
     "sphinx-jinja==2.0.2",
     "sphinx-notfound-page==1.1.0",
     "tox==4.24.1",
+    "sphinx-theme-builder[cli]==0.2.0b2",
 ]
 changelog = [
     "PyYAML==6.0.2",

--- a/tox.ini
+++ b/tox.ini
@@ -39,11 +39,10 @@ commands =
 
 [testenv:doc-{clean,links,html,pdf,serve}]
 description = Checks documentation links and pages generates properly
-deps=
-    serve: sphinx-theme-builder[cli] @ https://github.com/pradyunsg/sphinx-theme-builder/archive/d9f620b1a73839728c95b596343595d3952ec8bf.zip
+skip_install =
+    clean: true
 allowlist_externals =
     pdf: pdflatex
-    serve: stb
 extras = doc
 setenv =
     SOURCE_DIR = doc/source
@@ -55,7 +54,7 @@ setenv =
 commands =
     links,html,pdf: sphinx-build -d "{toxworkdir}/doc_doctree" {env:SOURCE_DIR} "{toxinidir}/{env:BUILD_DIR}/{env:BUILDER}" {env:BUILDER_OPTS} -b {env:BUILDER}
     clean: python -c "import shutil, sys; shutil.rmtree(sys.argv[1], ignore_errors=True)" "{toxinidir}/{env:BUILD_DIR}"
-    serve: stb serve "{toxinidir}/{env:SOURCE_DIR}" --open-browser
+    serve: stb serve "{toxinidir}/{env:SOURCE_DIR}/"
 
 [testenv:dist]
 description = Checks project distribution

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,7 @@ description = Default tox environments list
 envlist =
     code-style
     doc-style
-    doc-{links,html,pdf,clean}
-    doc-preview
+    doc-{links,html,pdf,clean,serve}
     dist
 skip_missing_interpreters = true
 isolated_build = true

--- a/tox.ini
+++ b/tox.ini
@@ -65,7 +65,9 @@ commands =
 description = Build and serve documentation locally
 allowlist_externals =
     stb
-extras = doc, "sphinx-theme-builder[cli]"
+extras = doc
+deps =
+    sphinx-theme-builder[cli] @ https://github.com/pradyunsg/sphinx-theme-builder/archive/d9f620b1a73839728c95b596343595d3952ec8bf.zip
 setenv =
     SOURCE_DIR = doc/source
     BUILD_DIR = doc/_build

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     code-style
     doc-style
     doc-{links,html,pdf,clean}
+    doc-preview
     dist
 skip_missing_interpreters = true
 isolated_build = true
@@ -50,7 +51,7 @@ setenv =
     links,html,pdf: BUILDER_OPTS = --color -v -j auto -W --keep-going
 commands =
     links,html,pdf: sphinx-build -d "{toxworkdir}/doc_doctree" {env:SOURCE_DIR} "{toxinidir}/{env:BUILD_DIR}/{env:BUILDER}" {env:BUILDER_OPTS} -b {env:BUILDER}
-     clean: python -c "import shutil, sys; shutil.rmtree(sys.argv[1], ignore_errors=True)" "{toxinidir}/{env:BUILD_DIR}"
+    clean: python -c "import shutil, sys; shutil.rmtree(sys.argv[1], ignore_errors=True)" "{toxinidir}/{env:BUILD_DIR}"
 
 [testenv:dist]
 description = Checks project distribution
@@ -59,3 +60,14 @@ deps =
     build
 commands =
     python -m build {toxinidir}
+
+[testenv:doc-preview]
+description = Build and serve documentation locally
+allowlist_externals =
+    stb
+extras = doc, "sphinx-theme-builder[cli]"
+setenv =
+    SOURCE_DIR = doc/source
+    BUILD_DIR = doc/_build
+commands =
+    stb serve "{toxinidir}/{env:SOURCE_DIR}" --open-browser

--- a/tox.ini
+++ b/tox.ini
@@ -37,10 +37,13 @@ commands =
     vale sync --config="{toxinidir}/doc/.vale.ini"
     vale --config="{toxinidir}/doc/.vale.ini" "{toxinidir}/doc"
 
-[testenv:doc-{clean,links,html,pdf}]
+[testenv:doc-{clean,links,html,pdf,serve}]
 description = Checks documentation links and pages generates properly
+deps=
+    serve: sphinx-theme-builder[cli] @ https://github.com/pradyunsg/sphinx-theme-builder/archive/d9f620b1a73839728c95b596343595d3952ec8bf.zip
 allowlist_externals =
-    pdflatex
+    pdf: pdflatex
+    serve: stb
 extras = doc
 setenv =
     SOURCE_DIR = doc/source
@@ -52,6 +55,7 @@ setenv =
 commands =
     links,html,pdf: sphinx-build -d "{toxworkdir}/doc_doctree" {env:SOURCE_DIR} "{toxinidir}/{env:BUILD_DIR}/{env:BUILDER}" {env:BUILDER_OPTS} -b {env:BUILDER}
     clean: python -c "import shutil, sys; shutil.rmtree(sys.argv[1], ignore_errors=True)" "{toxinidir}/{env:BUILD_DIR}"
+    serve: stb serve "{toxinidir}/{env:SOURCE_DIR}" --open-browser
 
 [testenv:dist]
 description = Checks project distribution
@@ -60,16 +64,3 @@ deps =
     build
 commands =
     python -m build {toxinidir}
-
-[testenv:doc-preview]
-description = Build and serve documentation locally
-allowlist_externals =
-    stb
-extras = doc
-deps =
-    sphinx-theme-builder[cli] @ https://github.com/pradyunsg/sphinx-theme-builder/archive/d9f620b1a73839728c95b596343595d3952ec8bf.zip
-setenv =
-    SOURCE_DIR = doc/source
-    BUILD_DIR = doc/_build
-commands =
-    stb serve "{toxinidir}/{env:SOURCE_DIR}" --open-browser


### PR DESCRIPTION
This PR introduces a new Tox environment, `[testenv:doc-serve]`, to build and serve the documentation locally. 

1. Adds [testenv:doc-serve] to build and serve docs locally.
2. Uses stb serve for live preview.
3. Includes necessary dependencies and environment setup.
4. Helps in testing documentation changes more efficiently.