### PR TITLE
fix: quarto error logging

### DIFF
--- a/doc/changelog.d/658.fixed.md
+++ b/doc/changelog.d/658.fixed.md
@@ -1,0 +1,1 @@
+quarto error logging

--- a/src/ansys_sphinx_theme/cheatsheet.py
+++ b/src/ansys_sphinx_theme/cheatsheet.py
@@ -107,8 +107,13 @@ def run_quarto_command(command: List[str], cwd: str) -> None:
         if result.stdout:
             logger.info(result.stdout)
 
-        if result.stderr and "Error" in result.stderr:
-            logger.error(result.stderr)
+        if result.stderr:
+            if "error" or "failed" in result.stderr.lower():
+                logger.error(result.stderr)
+            else:
+                # HACK: Quarto writes both stdout and stderr to stderr
+                # so we need to log it as info if it's not an error
+                logger.info(result.stderr)
 
     except subprocess.CalledProcessError as e:
         raise RuntimeError(f"Failed to run the command: {e}")

--- a/src/ansys_sphinx_theme/cheatsheet.py
+++ b/src/ansys_sphinx_theme/cheatsheet.py
@@ -107,7 +107,7 @@ def run_quarto_command(command: List[str], cwd: str) -> None:
         if result.stdout:
             logger.info(result.stdout)
 
-        if result.stderr:
+        if result.stderr and "Error" in result.stderr:
             logger.error(result.stderr)
 
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
Quarto writes both stdout and stderr to stderr so we need to log it as info if it's not an error

error noticed in https://github.com/ansys/pymapdl/actions/runs/14087805194/job/39456752974?pr=2346#step:22:189