### PR TITLE
feat: small layout adjustments

### DIFF
--- a/doc/changelog.d/691.added.md
+++ b/doc/changelog.d/691.added.md
@@ -1,0 +1,1 @@
+small layout adjustments

--- a/src/ansys_sphinx_theme/__init__.py
+++ b/src/ansys_sphinx_theme/__init__.py
@@ -156,8 +156,11 @@ def setup_default_html_theme_options(app):
     # Place all switchers and icons at the end of the navigation bar
     if theme_options.get("switcher"):
         theme_options.setdefault(
-            "navbar_end", ["version-switcher", "theme-switcher", "navbar-icon-links"]
+            "navbar_end",
+            ["search-field", "version-switcher", "theme-switcher", "navbar-icon-links"],
         )
+
+    theme_options.setdefault("navbar_persistent", [])
     theme_options.setdefault("collapse_navigation", True)
     theme_options.setdefault("navigation_with_keys", True)
 

--- a/src/ansys_sphinx_theme/__init__.py
+++ b/src/ansys_sphinx_theme/__init__.py
@@ -157,7 +157,7 @@ def setup_default_html_theme_options(app):
     if theme_options.get("switcher"):
         theme_options.setdefault(
             "navbar_end",
-            ["search-field", "version-switcher", "theme-switcher", "navbar-icon-links"],
+            ["search-button-field", "version-switcher", "theme-switcher", "navbar-icon-links"],
         )
 
     theme_options.setdefault("navbar_persistent", [])

--- a/src/ansys_sphinx_theme/assets/styles/ansys-sphinx-theme.scss
+++ b/src/ansys_sphinx_theme/assets/styles/ansys-sphinx-theme.scss
@@ -42,3 +42,11 @@ p.rubric {
 .autosummary tr:nth-child(even) {
   background-color: var(--pst-color-background);
 }
+
+/*
+* Navbar styles
+*/
+
+.bd-navbar-elements {
+    text-align: center;
+}

--- a/src/ansys_sphinx_theme/assets/styles/ansys-sphinx-theme.scss
+++ b/src/ansys_sphinx_theme/assets/styles/ansys-sphinx-theme.scss
@@ -50,3 +50,7 @@ p.rubric {
 .bd-navbar-elements {
     text-align: center;
 }
+
+.bd-main .bd-content {
+    justify-content: center;
+}


### PR DESCRIPTION
- Center navbar elements
- Centering `bd-content` container. This is more obvious when we hide any of the sidebars.
- Moving search bar to `navbar_end` so it hides when there is no space. This change probably needs some thoughts. Since the search bar "disappear" for small screens and gets located in the primary sidebar:

<img width="718" alt="image" src="https://github.com/user-attachments/assets/88e03b78-55d5-46eb-a87b-ed54c83af646" />


## Changes
### Center navbar elements
#### Before
<img width="855" alt="image" src="https://github.com/user-attachments/assets/9867cba7-5c7e-43d3-8459-f0818292c52f" />

#### After
<img width="644" alt="image" src="https://github.com/user-attachments/assets/db03c43e-360c-48a9-9cfa-8680af933339" />

### Centering `bd-content` container. This is more obvious when we hide any of the sidebars.
#### Before
<img width="1462" alt="image" src="https://github.com/user-attachments/assets/b13ef1b2-b226-4d40-bd22-02fae0389f47" />

#### After
<img width="1454" alt="image" src="https://github.com/user-attachments/assets/336817c4-907e-4256-96ce-20167506fc93" />

### Moving search bar to `navbar_end` so it hides when there is no space. Better looking on mobile devices
#### Before
<img width="438" alt="image" src="https://github.com/user-attachments/assets/0f9cffad-0a15-4844-b15a-ec00a53f36bc" />

#### After
<img width="660" alt="image" src="https://github.com/user-attachments/assets/33015bc5-2368-407d-a010-98a361064875" />
