### PR TITLE
fix: style for back to top button

### DIFF
--- a/doc/changelog.d/693.fixed.md
+++ b/doc/changelog.d/693.fixed.md
@@ -1,0 +1,1 @@
+style for back to top button

--- a/src/ansys_sphinx_theme/assets/styles/ansys-sphinx-theme.scss
+++ b/src/ansys_sphinx_theme/assets/styles/ansys-sphinx-theme.scss
@@ -54,3 +54,9 @@ p.rubric {
 .bd-main .bd-content {
     justify-content: center;
 }
+
+/* Back to top button */
+#pst-back-to-top {
+    background: var(--ast-color-text);
+    color: var(--pst-color-on-surface);
+}

--- a/src/ansys_sphinx_theme/assets/styles/ansys-sphinx-theme.scss
+++ b/src/ansys_sphinx_theme/assets/styles/ansys-sphinx-theme.scss
@@ -54,3 +54,17 @@ p.rubric {
 .bd-main .bd-content {
     justify-content: center;
 }
+
+/* Back to top button */
+#pst-back-to-top {
+    background: var(--ast-color-active-text);
+    color: var(--pst-color-on-surface);
+    opacity: 0.7;
+}
+
+#pst-back-to-top:hover {
+    background: var(--ast-color-text);
+    color: var(--pst-color-on-surface);
+    font-weight: bold;
+    opacity: 1;
+}

--- a/src/ansys_sphinx_theme/assets/styles/ansys-sphinx-theme.scss
+++ b/src/ansys_sphinx_theme/assets/styles/ansys-sphinx-theme.scss
@@ -54,9 +54,3 @@ p.rubric {
 .bd-main .bd-content {
     justify-content: center;
 }
-
-/* Back to top button */
-#pst-back-to-top {
-    background: var(--ast-color-text);
-    color: var(--pst-color-on-surface);
-}

--- a/src/ansys_sphinx_theme/assets/styles/pydata-sphinx-theme-custom.scss
+++ b/src/ansys_sphinx_theme/assets/styles/pydata-sphinx-theme-custom.scss
@@ -332,11 +332,6 @@ strong {
   font-weight: 500;
 }
 
-#pst-back-to-top {
-  background: var(--ast-color-link);
-  color: var(--ast-color-text);
-}
-
 /**
 * _api.scss related changes
 */


### PR DESCRIPTION
As the title.

## Before 
See #692


## After

### Light theme
#### No hover

<img width="363" alt="image" src="https://github.com/user-attachments/assets/e5eee6e2-1fc7-406a-9b95-eec8336d94df" />

#### Hover
Just changed the font weight to bold, and removed transparency

<img width="170" alt="image" src="https://github.com/user-attachments/assets/ec2f6e68-0318-4ab6-834f-bca30c15c82d" />

### Dark theme

#### No hover

<img width="369" alt="image" src="https://github.com/user-attachments/assets/593e0c53-cc19-4a1f-94b9-29e1e26be20a" />

#### Hover

<img width="272" alt="image" src="https://github.com/user-attachments/assets/6fa49d2a-7c58-4136-b6f5-0a623fccb2a2" />
