### PR TITLE
Update README.rst to fix label from black to ruff

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 Ansys Sphinx theme
 ==================
-|ansys| |python| |pypi| |GH-CI| |MIT| |black|
+|ansys| |python| |pypi| |GH-CI| |MIT| |Ruff|
 
 .. |ansys| image:: https://img.shields.io/badge/Ansys-ffc107.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAABDklEQVQ4jWNgoDfg5mD8vE7q/3bpVyskbW0sMRUwofHD7Dh5OBkZGBgW7/3W2tZpa2tLQEOyOzeEsfumlK2tbVpaGj4N6jIs1lpsDAwMJ278sveMY2BgCA0NFRISwqkhyQ1q/Nyd3zg4OBgYGNjZ2ePi4rB5loGBhZnhxTLJ/9ulv26Q4uVk1NXV/f///////69du4Zdg78lx//t0v+3S88rFISInD59GqIH2esIJ8G9O2/XVwhjzpw5EAam1xkkBJn/bJX+v1365hxxuCAfH9+3b9/+////48cPuNehNsS7cDEzMTAwMMzb+Q2u4dOnT2vWrMHu9ZtzxP9vl/69RVpCkBlZ3N7enoDXBwEAAA+YYitOilMVAAAAAElFTkSuQmCC
    :target: https://github.com/ansys
@@ -22,13 +22,13 @@ Ansys Sphinx theme
    :target: https://opensource.org/licenses/MIT
    :alt: MIT
 
-.. |black| image:: https://img.shields.io/badge/code_style-black-000000.svg?style=flat
-   :target: https://github.com/psf/black
-   :alt: Black
-
 .. |Downloads| image:: https://img.shields.io/pypi/dm/ansys-sphinx-theme.svg?label=PyPI%20downloads
    :target: https://pypi.org/project/ansys-sphinx-theme
    :alt: Downloads
+
+.. |Ruff| image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
+   :target: https://github.com/astral-sh/ruff
+   :alt: Ruff
 
 
 Introduction


### PR DESCRIPTION
I noticed that this repository is using ruff after watching black badge in README.rst.