### PR TITLE
fix: remove font weight on highlight

### DIFF
--- a/doc/changelog.d/721.fixed.md
+++ b/doc/changelog.d/721.fixed.md
@@ -1,0 +1,1 @@
+remove font weight on highlight

--- a/src/ansys_sphinx_theme/assets/styles/ast-search.scss
+++ b/src/ansys_sphinx_theme/assets/styles/ast-search.scss
@@ -51,9 +51,8 @@
 }
 
 /* Highlighted Text */
-html[data-theme="light"] .highlight {
+html[data-theme="light"] .search-highlight {
   color: var(--pst-color-text-base);
-  font-weight: var(--ast-font-weight-bold);
 }
 
 /* Search Input Styles */

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/js/search-main.js
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/js/search-main.js
@@ -406,9 +406,12 @@ require(["fuse"], function (Fuse) {
           ...result,
           title: result.title.replace(
             regex,
-            `<span class="highlight">$1</span>`,
+            `<span class="search-highlight">$1</span>`,
           ),
-          text: snippet.replace(regex, `<span class="highlight">$1</span>`),
+          text: snippet.replace(
+            regex,
+            `<span class="search-highlight">$1</span>`,
+          ),
         };
       })
       .filter(Boolean);


### PR DESCRIPTION
The highlight on search makes the codeblocks to bold, https://acp.docs.pyansys.com/version/dev/user_guide/howto/copy_objects.html. In this PR, 
- Remove the weight to highlight in general
- Rename the highlight class to search-highlight  