### PR TITLE
fix: cache of autoapi options with ansys sphinx theme

### DIFF
--- a/doc/changelog.d/728.fixed.md
+++ b/doc/changelog.d/728.fixed.md
@@ -1,0 +1,1 @@
+Cache of autoapi options with ansys sphinx theme

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -98,7 +98,6 @@ extensions = [
     "sphinx.ext.todo",
     "sphinx_copybutton",
     "sphinx.ext.intersphinx",
-    "sphinx.ext.todo",
     "notfound.extension",
     "sphinx_jinja",
 ]

--- a/src/ansys_sphinx_theme/extension/autoapi.py
+++ b/src/ansys_sphinx_theme/extension/autoapi.py
@@ -109,7 +109,6 @@ def setup(app: Sphinx) -> Dict[str, Any]:
         if extension not in app.config["extensions"]:
             app.setup_extension(extension)
 
-    # app.connect("builder-inited", add_autoapi_theme_option, priority=400)
     app.connect("config-inited", add_autoapi_theme_option)
     return {
         "version": __version__,

--- a/src/ansys_sphinx_theme/extension/autoapi.py
+++ b/src/ansys_sphinx_theme/extension/autoapi.py
@@ -39,7 +39,7 @@ AUTOAPI_OPTIONS = [
 ]
 
 
-def add_autoapi_theme_option(app: Sphinx) -> None:
+def add_autoapi_theme_option(app: Sphinx, config: Dict[str, Any]) -> None:
     """Add the autoapi template path to the theme options.
 
     Parameters
@@ -47,7 +47,7 @@ def add_autoapi_theme_option(app: Sphinx) -> None:
     app : ~sphinx.application.Sphinx
         Application instance for rendering the documentation.
     """
-    autoapi = app.config.html_theme_options.get("ansys_sphinx_theme_autoapi", {})
+    autoapi = config.html_theme_options.get("ansys_sphinx_theme_autoapi", {})
     if not autoapi:
         return
     autoapi_template_dir = autoapi.get("templates", "")
@@ -56,7 +56,7 @@ def add_autoapi_theme_option(app: Sphinx) -> None:
     if not autoapi_template_dir:
         autoapi_template_dir = get_autoapi_templates_dir_relative_path(app.confdir)
 
-    app.config["autoapi_template_dir"] = autoapi_template_dir
+    config["autoapi_template_dir"] = autoapi_template_dir
 
     def prepare_jinja_env(jinja_env) -> None:
         """Prepare the Jinja environment for the theme."""
@@ -65,19 +65,17 @@ def add_autoapi_theme_option(app: Sphinx) -> None:
 
     # Set the autoapi options
 
-    app.config["autoapi_prepare_jinja_env"] = prepare_jinja_env
-    app.config["autoapi_type"] = autoapi.get("type", "python")
-    app.config["autoapi_root"] = autoapi.get("output", "api")
-    app.config["autoapi_own_page_level"] = autoapi.get("own_page_level", "class")
-    app.config["autoapi_python_use_implicit_namespaces"] = autoapi.get(
-        "use_implicit_namespaces", True
-    )
-    app.config["autoapi_keep_files"] = autoapi.get("keep_files", True)
-    app.config["autoapi_python_class_content"] = autoapi.get("class_content", "class")
-    app.config["autoapi_options"] = autoapi.get("options", AUTOAPI_OPTIONS)
-    app.config["autoapi_ignore"] = autoapi.get("ignore", [])
-    app.config["autoapi_add_toctree_entry"] = autoapi.get("add_toctree_entry", True)
-    app.config["autoapi_member_order"] = autoapi.get("member_order", "bysource")
+    config["autoapi_prepare_jinja_env"] = prepare_jinja_env
+    config["autoapi_type"] = autoapi.get("type", "python")
+    config["autoapi_root"] = autoapi.get("output", "api")
+    config["autoapi_own_page_level"] = autoapi.get("own_page_level", "class")
+    config["autoapi_python_use_implicit_namespaces"] = autoapi.get("use_implicit_namespaces", True)
+    config["autoapi_keep_files"] = autoapi.get("keep_files", True)
+    config["autoapi_python_class_content"] = autoapi.get("class_content", "class")
+    config["autoapi_options"] = autoapi.get("options", AUTOAPI_OPTIONS)
+    config["autoapi_ignore"] = autoapi.get("ignore", [])
+    config["autoapi_add_toctree_entry"] = autoapi.get("add_toctree_entry", True)
+    config["autoapi_member_order"] = autoapi.get("member_order", "bysource")
 
     # HACK: The ``autoapi_dirs`` should be given as a relative path to the conf.py.
     autoapi_dir = autoapi.get("directory", "src/ansys")
@@ -88,7 +86,7 @@ def add_autoapi_theme_option(app: Sphinx) -> None:
         relative_autoapi_dir = os.path.relpath(path_to_autoapi_dir, start=app.srcdir)
     else:
         relative_autoapi_dir = autoapi_dir
-    app.config["autoapi_dirs"] = [str(relative_autoapi_dir)]
+    config["autoapi_dirs"] = [str(relative_autoapi_dir)]
 
 
 def setup(app: Sphinx) -> Dict[str, Any]:
@@ -105,12 +103,14 @@ def setup(app: Sphinx) -> Dict[str, Any]:
         A dictionary containing the version and parallel read/write safety flags.
     """
     # HACK: The ``autoapi.extension``,  ``sphinx_design``, and ``sphinx_jinja`` extensions should be
-    # added to the Sphinx
+    # added to the Sphinx configuration.
     required_extensions = ["sphinx_design", "sphinx_jinja", "autoapi.extension"]
     for extension in required_extensions:
         if extension not in app.config["extensions"]:
             app.setup_extension(extension)
-    app.connect("builder-inited", add_autoapi_theme_option, priority=400)
+
+    # app.connect("builder-inited", add_autoapi_theme_option, priority=400)
+    app.connect("config-inited", add_autoapi_theme_option)
     return {
         "version": __version__,
         "parallel_read_safe": True,


### PR DESCRIPTION
This PR removes all AutoAPI-related options from the theme configuration to avoid conflicts and duplication in the pickled environment as mentioned in issue #725 . While we can't fully achieve a zero-config setup—since some settings like html_permalinks_icon and html_theme_options come from PyData Sphinx Theme and others like html_static_path from extensions like sphinx-design— and many mores from nbsphinx, this change ensures that only the core AutoAPI configuration (autoapi_prepare_jinja_env) is preserved. This simplifies the environment and prevents outdated theme-based config overrides.
# Before
![Screenshot 2025-06-12 at 17 32 55](https://github.com/user-attachments/assets/8592d4b9-f167-4eb0-9acd-98eb20f3bf20)


# After 
![Screenshot 2025-06-12 at 17 31 20](https://github.com/user-attachments/assets/c570d09f-4f62-44bb-a2e8-49e6a68e655d)
