### PR TITLE
fix(style): update the literal  `codespace` to `monospace` font

### DIFF
--- a/doc/changelog.d/744.fixed.md
+++ b/doc/changelog.d/744.fixed.md
@@ -1,1 +1,1 @@
-Update the literal  `codespace` to `monospace`font
+Update the literal  `codespace` to `monospace` font

--- a/doc/changelog.d/744.fixed.md
+++ b/doc/changelog.d/744.fixed.md
@@ -1,0 +1,1 @@
+Update the literal  `codespace` to `monospace`font

--- a/src/ansys_sphinx_theme/assets/styles/pydata-sphinx-theme-custom.scss
+++ b/src/ansys_sphinx_theme/assets/styles/pydata-sphinx-theme-custom.scss
@@ -482,7 +482,7 @@ a > code {
 
 code.literal {
   color: var(--ast-color-inline-code);
-  font-family: var(--ast-sphinx-design-font-family);
+  font-family: var(--pst-font-family-monospace);
 }
 
 nav.bd-links li > a:focus-visible,


### PR DESCRIPTION
fix #548 

This PR Intended to change the font from `open-sans
` to ``monospace`` in the literal code blocks as shown in image below:

![Screenshot 2025-07-01 at 08 42 25](https://github.com/user-attachments/assets/5627fc14-ad37-4992-aadf-5becd7422b06)

![Screenshot 2025-07-01 at 08 46 11](https://github.com/user-attachments/assets/ccc1a0b9-2b6e-4212-afc1-66ffb615199a)

