### PR TITLE
fix: remove deprecated theme option from code base

### DIFF
--- a/doc/changelog.d/755.fixed.md
+++ b/doc/changelog.d/755.fixed.md
@@ -1,0 +1,1 @@
+Remove deprecated theme option from code base

--- a/src/ansys_sphinx_theme/search/__init__.py
+++ b/src/ansys_sphinx_theme/search/__init__.py
@@ -42,10 +42,6 @@ def update_search_config(app: Sphinx) -> None:
     theme_static_options["limit"] = theme_static_options.get("limit", 10)
     app.config.html_theme_options["static_search"] = theme_static_options
 
-    # TODO (RV): Deprecate this in release 0.16.0
-    # https://github.com/ansys/ansys-sphinx-theme/issues/730
-    app.add_config_value("index_patterns", {}, "html")
-
 
 __all__ = [
     "create_search_index",

--- a/src/ansys_sphinx_theme/search/fuse_search.py
+++ b/src/ansys_sphinx_theme/search/fuse_search.py
@@ -194,16 +194,6 @@ def create_search_index(app, exception):
     included_docs = app.env.found_docs
     filter_options = app.config.html_theme_options.get("search_filters", {})
 
-    # TODO (RV): Deprecate this in release 0.16.0
-    # https://github.com/ansys/ansys-sphinx-theme/issues/730
-    patterns = app.env.config.index_patterns or {}
-    if patterns:
-        raise TypeError(
-            "The 'index_patterns' is deprecated and no longer supported. "
-            "Please see the documentation https://sphinxdocs.ansys.com for the "
-            "new search configuration options."
-        )
-
     for exclude_doc in excluded_docs:
         exclude_doc = Path(exclude_doc).resolve()
 


### PR DESCRIPTION
fix #730
This pull request removes a deprecated theme option (`index_patterns`) from the codebase and updates related functionality and documentation. The changes clean up the code and ensure that the deprecated feature is no longer supported.