### PR TITLE
feat: add multiple tags for `meta-data`

### DIFF
--- a/doc/changelog.d/758.added.md
+++ b/doc/changelog.d/758.added.md
@@ -1,0 +1,1 @@
+Add multiple tags for `meta-data`

--- a/doc/source/user-guide/configuration.rst
+++ b/doc/source/user-guide/configuration.rst
@@ -148,7 +148,7 @@ If you want to add multiple physics tags, you can do so by providing a list of t
        "pyansys_tags": ["Electromagnetics", "Structures", "Fluids"],
    }
 
-This will result in multiple `<meta>` tags in your HTML pages:
+This result in multiple `<meta>` tags in your HTML pages:
 
 .. code-block:: html
 

--- a/doc/source/user-guide/configuration.rst
+++ b/doc/source/user-guide/configuration.rst
@@ -140,6 +140,23 @@ which result in the following metadata in your HTML pages:
     <meta property="og:site_name" content="PyAnsys" />
     <meta name="physics" content="Electromagnetics" />
 
+If you want to add multiple physics tags, you can do so by providing a list of tags:
+
+.. code-block:: python
+
+   html_context = {
+       "pyansys_tag": ["Electromagnetics", "Structures", "Fluids"],
+   }
+
+This will result in multiple `<meta>` tags in your HTML pages:
+
+.. code-block:: html
+
+    <meta property="og:site_name" content="PyAnsys" />
+    <meta name="physics" content="Electromagnetics" />
+    <meta name="physics" content="Structures" />
+    <meta name="physics" content="Fluids" />
+
 
 PDF cover page
 ~~~~~~~~~~~~~~

--- a/doc/source/user-guide/configuration.rst
+++ b/doc/source/user-guide/configuration.rst
@@ -121,16 +121,16 @@ The switcher requires a ``versions.json`` file that contains the versions of the
 For more information, see `PyAnsys multi-version documentation <dev_guide_multi_version_>`_ in the
 *PyAnsys developer's guide*.
 
-PyAnsys tag
+PyAnsys tags
 ~~~~~~~~~~~~
 The Ansys Sphinx Theme allows you to add a physics tag in your metadata based on the pyansys category.
 This can be useful for categorizing content related to specific physics domains, such as ``Electromagnetics``, ``Structures``, or ``Fluids``.
-You can add a physics tag to your documentation by setting the ``pyansys_tag`` option in your project's Sphinx ``conf.py`` file.
+You can add a physics tag to your documentation by setting the ``pyansys_tags`` option in your project's Sphinx ``conf.py`` file.
 
 .. code-block:: python
 
    html_context = {
-       "pyansys_tag": "Electromagnetics",
+       "pyansys_tags": ["Electromagnetics"],
    }
 
 which result in the following metadata in your HTML pages:
@@ -145,7 +145,7 @@ If you want to add multiple physics tags, you can do so by providing a list of t
 .. code-block:: python
 
    html_context = {
-       "pyansys_tag": ["Electromagnetics", "Structures", "Fluids"],
+       "pyansys_tags": ["Electromagnetics", "Structures", "Fluids"],
    }
 
 This will result in multiple `<meta>` tags in your HTML pages:

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/layout.html
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/layout.html
@@ -4,7 +4,13 @@
   {{ super() }}
   {%- if pyansys_tag is defined %}
   <meta property="og:site_name" content="PyAnsys" />
+    {%- if pyansys_tag is iterable and not pyansys_tag is string %}
+      {%- for tag in pyansys_tag %}
+  <meta name="physics" content="{{ tag }}" />
+      {%- endfor %}
+    {%- else %}
   <meta name="physics" content="{{ pyansys_tag }}" />
+    {%- endif %}
   {%- endif %}
 {%- endblock %}
 

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/layout.html
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/layout.html
@@ -2,14 +2,14 @@
 
 {%- block extrahead %}
   {{ super() }}
-  {%- if pyansys_tag is defined %}
+  {%- if pyansys_tags is defined %}
   <meta property="og:site_name" content="PyAnsys" />
-    {%- if pyansys_tag is iterable and not pyansys_tag is string %}
-      {%- for tag in pyansys_tag %}
+    {%- if pyansys_tags is iterable and not pyansys_tags is string %}
+      {%- for tag in pyansys_tags %}
   <meta name="physics" content="{{ tag }}" />
       {%- endfor %}
     {%- else %}
-  <meta name="physics" content="{{ pyansys_tag }}" />
+  <meta name="physics" content="{{ pyansys_tags }}" />
     {%- endif %}
   {%- endif %}
 {%- endblock %}


### PR DESCRIPTION
This pull request introduces functionality to support multiple physics tags in the PyAnsys HTML metadata. The changes include updates to both the documentation and the HTML layout template to handle lists of physics tags.