### PR TITLE
fix: `backstop` tests issue with collapsible sidebar

### DIFF
--- a/doc/changelog.d/955.fixed.md
+++ b/doc/changelog.d/955.fixed.md
@@ -1,0 +1,1 @@
+\`backstop\` tests issue with collapsible sidebar

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -82,6 +82,7 @@ html_theme_options = {
         "Examples": ["examples/"],
         "Contributing": ["contribute/"],
     },
+    "collapse_navigation": True,
 }
 
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -82,7 +82,6 @@ html_theme_options = {
         "Examples": ["examples/"],
         "Contributing": ["contribute/"],
     },
-    "collapse_navigation": True,
 }
 
 

--- a/tests/backstop.json
+++ b/tests/backstop.json
@@ -21,16 +21,9 @@
       "readyEvent": "",
       "readySelector": "",
       "delay": 20,
-      "hideSelectors": [],
-      "removeSelectors": [],
-      "hoverSelector": "",
-      "clickSelector": "",
-      "postInteractionWait": 0,
-      "selectors": [],
-      "selectorExpansion": true,
-      "expect": 0,
+      "selectors": ["viewport"],
       "misMatchThreshold" : 0.2,
-      "requireSameDimensions": true
+      "requireSameDimensions": false
     },
     {
       "label": "Ansys Sphinx Theme - sphinx design example page",

--- a/tests/backstop.json
+++ b/tests/backstop.json
@@ -33,7 +33,7 @@
       "readySelector": "",
       "delay": 20,
       "selectors": ["viewport"],
-      "misMatchThreshold" : 0.2,
+      "misMatchThreshold" : 0.5,
       "requireSameDimensions": false
     },
     {
@@ -55,7 +55,7 @@
       "readySelector": "",
       "delay": 20,
       "selectors": ["viewport"],
-      "misMatchThreshold" : 2.0,
+      "misMatchThreshold" : 0.2,
       "requireSameDimensions": false,
       "viewports": [
       {
@@ -73,7 +73,7 @@
       "readySelector": "",
       "delay": 20,
       "selectors": ["viewport"],
-      "misMatchThreshold" : 2.0,
+      "misMatchThreshold" : 0.2,
       "requireSameDimensions": false
     },
     {
@@ -93,7 +93,7 @@
       "referenceUrl": "https://sphinxdocs.ansys.com/version/dev/examples/gallery-examples/index.html",
       "delay": 20,
       "selectors": ["viewport"],
-      "misMatchThreshold" : 2.0,
+      "misMatchThreshold" : 0.2,
       "requireSameDimensions": false
     }
   ],

--- a/tests/backstop.json
+++ b/tests/backstop.json
@@ -39,6 +39,7 @@
       "readyEvent": "",
       "readySelector": "",
       "delay": 20,
+      "selectors": ["viewport"],
       "misMatchThreshold" : 0.2,
       "requireSameDimensions": false
     },
@@ -49,7 +50,8 @@
       "readyEvent": "",
       "readySelector": "",
       "delay": 20,
-      "misMatchThreshold" : 0.5,
+      "selectors": ["viewport"],
+      "misMatchThreshold" : 2.0,
       "requireSameDimensions": false
     },
     {
@@ -59,7 +61,8 @@
       "readyEvent": "",
       "readySelector": "",
       "delay": 20,
-      "misMatchThreshold" : 2.5,
+      "selectors": ["viewport"],
+      "misMatchThreshold" : 2.0,
       "requireSameDimensions": false,
       "viewports": [
       {
@@ -76,7 +79,8 @@
       "readyEvent": "",
       "readySelector": "",
       "delay": 20,
-      "misMatchThreshold" : 0.2,
+      "selectors": ["viewport"],
+      "misMatchThreshold" : 2.0,
       "requireSameDimensions": false
     },
     {
@@ -86,7 +90,8 @@
       "readyEvent": "",
       "readySelector": "",
       "delay": 20,
-      "misMatchThreshold" : 0.2,
+      "selectors": ["viewport"],
+      "misMatchThreshold" : 3.0,
       "requireSameDimensions": false
     },
     {
@@ -94,7 +99,8 @@
       "url": "http://localhost:8000/examples/gallery-examples/index.html",
       "referenceUrl": "https://sphinxdocs.ansys.com/version/dev/examples/gallery-examples/index.html",
       "delay": 20,
-      "misMatchThreshold" : 0.2,
+      "selectors": ["viewport"],
+      "misMatchThreshold" : 2.0,
       "requireSameDimensions": false
     }
   ],
@@ -112,7 +118,14 @@
   "report": ["browser","CI"],
   "engine": "puppet",
   "engineOptions": {
-    "args": ["--no-sandbox"]
+    "args": [
+      "--no-sandbox"
+    ],
+    "defaultViewport": {
+      "width": 1920,
+      "height": 1080,
+      "deviceScaleFactor": 1
+    }
   },
   "asyncCaptureLimit": 5,
   "asyncCompareLimit": 50,

--- a/tests/backstop.json
+++ b/tests/backstop.json
@@ -3,8 +3,8 @@
   "viewports": [
     {
       "label": "tablet",
-      "width": 1024,
-      "height": 768
+      "width": 1440,
+      "height": 900
     },
     {
       "label": "desktop",


### PR DESCRIPTION
part of #932 

BackstopJS by default captures the full scrollable page height. For long documentation pages, this caused the position: sticky sidebar to stretch to the full document height, producing screenshots that looked nothing like what a real browser renders. Using "selectors": ["viewport"] restricts capture to the visible window area, matching real browser behaviour.