### PR TITLE
fix: cheatsheet configurations in sidebar

### DIFF
--- a/doc/changelog.d/983.fixed.md
+++ b/doc/changelog.d/983.fixed.md
@@ -1,0 +1,1 @@
+Cheatsheet configurations in sidebar

--- a/src/ansys_sphinx_theme/__init__.py
+++ b/src/ansys_sphinx_theme/__init__.py
@@ -473,6 +473,7 @@ def add_sidebar_context(
 
     if cheatsheet_pages and pagename in cheatsheet_pages:
         sidebars_to_add.append("cheatsheet")
+        context["cheatsheet"] = app.config.html_theme_options.get("cheatsheet", {})
 
     if whatsnew_pages and pagename in whatsnew_pages:
         whatsnew = context.get("whatsnew", [])

--- a/src/ansys_sphinx_theme/assets/styles/pydata-sphinx-theme-custom.scss
+++ b/src/ansys_sphinx_theme/assets/styles/pydata-sphinx-theme-custom.scss
@@ -42,9 +42,10 @@
   border: none;
 }
 
-// Hide the primary sidebar when it contains no navigation links
-// (when only the **Section Navigation** heading is present)
-.bd-sidebar-primary:not(:has(nav.bd-links li)) {
+// Hide the primary sidebar when it contains no navigation links and no custom
+// sidebar content. The selector list inside :has() covers all content types
+// in a single check — add new sidebar component classes here if needed.
+.bd-sidebar-primary:not(:has(nav.bd-links li)):not(:has(.sidebar-cheatsheets, .whatsnew-sidebar)) {
   display: none;
 }
 nav.bd-links p.bd-links__title,

--- a/src/ansys_sphinx_theme/assets/styles/pydata-sphinx-theme-custom.scss
+++ b/src/ansys_sphinx_theme/assets/styles/pydata-sphinx-theme-custom.scss
@@ -43,9 +43,10 @@
 }
 
 // Hide the primary sidebar when it contains no navigation links and no custom
-// sidebar content. The selector list inside :has() covers all content types
-// in a single check — add new sidebar component classes here if needed.
-.bd-sidebar-primary:not(:has(nav.bd-links li)):not(:has(.sidebar-cheatsheets, .whatsnew-sidebar)) {
+// sidebar content. Every custom sidebar component must include the
+// `ast-sidebar-widget` class on its root element — this rule then works
+// automatically without any CSS changes for new components.
+.bd-sidebar-primary:not(:has(nav.bd-links li)):not(:has(.ast-sidebar-widget)) {
   display: none;
 }
 nav.bd-links p.bd-links__title,

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/components/cheatsheet_sidebar.html
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/components/cheatsheet_sidebar.html
@@ -4,17 +4,17 @@
   Displays a cheatsheet link and thumbnail in the sidebar if configured.
   Uses <div> for compatibility as requested.
 #}
-{% if theme_cheatsheet %}
-  {% set theme_cheatsheet_title = theme_cheatsheet.get('title', 'Cheatsheet') %}
-  {% set theme_cheatsheet_output_dir = theme_cheatsheet.get('output_dir') %}
-  {% set theme_cheatsheet_thumbnail = theme_cheatsheet.get('thumbnail') %}
-  {% set theme_cheatsheet_output = pathto(theme_cheatsheet_output_dir, 1) %}
-  {% set theme_cheatsheet_thumbnail = pathto(theme_cheatsheet_thumbnail, 1) %}
+{% if cheatsheet %}
+  {% set cheatsheet_title = cheatsheet.get('title', 'Cheatsheet') %}
+  {% set cheatsheet_output_dir = cheatsheet.get('output_dir') %}
+  {% set cheatsheet_thumbnail = cheatsheet.get('thumbnail') %}
+  {% set cheatsheet_output = pathto(cheatsheet_output_dir, 1) %}
+  {% set cheatsheet_thumbnail_path = pathto(cheatsheet_thumbnail, 1) %}
   <div class="sidebar-cheatsheets" aria-label="Cheatsheet">
-    <h4>{{ theme_cheatsheet_title }}</h4>
-    <a href="{{ theme_cheatsheet_output }}" target="_blank" rel="noopener noreferrer">
+    <h4>{{ cheatsheet_title }}</h4>
+    <a href="{{ cheatsheet_output }}" target="_blank" rel="noopener noreferrer">
       {# djlint:off H006 #}
-      <img src="{{ theme_cheatsheet_thumbnail }}" alt="{{ theme_cheatsheet_title }} thumbnail" loading="lazy" />
+      <img src="{{ cheatsheet_thumbnail_path }}" alt="{{ cheatsheet_title }} thumbnail" loading="lazy" />
       {# djlint:on H006 #}
     </a>
   </div>

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/components/cheatsheet_sidebar.html
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/components/cheatsheet_sidebar.html
@@ -10,7 +10,7 @@
   {% set cheatsheet_thumbnail = cheatsheet.get('thumbnail') %}
   {% set cheatsheet_output = pathto(cheatsheet_output_dir, 1) %}
   {% set cheatsheet_thumbnail_path = pathto(cheatsheet_thumbnail, 1) %}
-  <div class="sidebar-cheatsheets" aria-label="Cheatsheet">
+  <div class="sidebar-cheatsheets ast-sidebar-widget" aria-label="Cheatsheet">
     <h4>{{ cheatsheet_title }}</h4>
     <a href="{{ cheatsheet_output }}" target="_blank" rel="noopener noreferrer">
       {# djlint:off H006 #}

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/components/whatsnew_sidebar.html
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/components/whatsnew_sidebar.html
@@ -1,5 +1,5 @@
 {% if whatsnew %}
-<div class="whatsnew-sidebar">
+<div class="whatsnew-sidebar ast-sidebar-widget">
   <ul>
     {% for whatsnew in whatsnew %}
       {% set title = whatsnew.get('title') %}


### PR DESCRIPTION
Cheatsheet was not visible in the sidebar with latest release, because we were hiding all the components in the sidebar. 

After #943 

The two other bugs (wrong Jinja variable, missing context variable)