### PR TITLE
fix: collapse the search results bar after results

### DIFF
--- a/doc/changelog.d/986.fixed.md
+++ b/doc/changelog.d/986.fixed.md
@@ -1,0 +1,1 @@
+Collapse the search results bar after results

--- a/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/js/search.js
+++ b/src/ansys_sphinx_theme/theme/ansys_sphinx_theme/static/js/search.js
@@ -135,7 +135,10 @@ require(["fuse"], (Fuse) => {
       const resultItem = document.createElement("div");
       resultItem.className = "result-item";
       resultItem.dataset.href = href;
-      resultItem.addEventListener("click", () => navigateToHref(href));
+      resultItem.addEventListener("click", () => {
+        collapseSearchInput();
+        navigateToHref(href);
+      });
 
       const resultTitle = document.createElement("div");
       resultTitle.className = "result-title";
@@ -199,11 +202,16 @@ require(["fuse"], (Fuse) => {
         event.preventDefault();
         if (event.ctrlKey || event.metaKey) {
           const query = SEARCH_INPUT.value.trim();
+          collapseSearchInput();
           window.location.href = ADVANCE_SEARCH_PATH + "?q=" + query;
         } else if (CURRENT_INDEX >= 0 && CURRENT_INDEX < resultItems.length) {
-          navigateToHref(resultItems[CURRENT_INDEX].dataset.href);
+          const href = resultItems[CURRENT_INDEX].dataset.href;
+          collapseSearchInput();
+          navigateToHref(href);
         } else if (resultItems.length > 0) {
-          navigateToHref(resultItems[0].dataset.href);
+          const href = resultItems[0].dataset.href;
+          collapseSearchInput();
+          navigateToHref(href);
         }
         break;
       case "ArrowDown":


### PR DESCRIPTION
fix #987 

## before 
<img width="1577" height="691" alt="Screenshot 2026-05-21 at 16 10 24" src="https://github.com/user-attachments/assets/8a076ea2-b700-4b61-b408-63f6c41467e1" />

## after
<img width="1519" height="880" alt="Screenshot 2026-05-21 at 16 11 13" src="https://github.com/user-attachments/assets/fd115239-fcce-4f53-871c-461cc766cbdf" />

