### PR TITLE
fix: target color style

### DIFF
--- a/doc/changelog.d/989.fixed.md
+++ b/doc/changelog.d/989.fixed.md
@@ -1,0 +1,1 @@
+Target color style

--- a/src/ansys_sphinx_theme/assets/styles/pydata-sphinx-theme-custom.scss
+++ b/src/ansys_sphinx_theme/assets/styles/pydata-sphinx-theme-custom.scss
@@ -917,3 +917,11 @@ code, kbd, pre, samp {
   padding-inline-start: 0;
   width: 100%;
 }
+
+/**
+ * Target style for headings
+  */
+
+.bd-main .bd-content .bd-article-container .bd-article :target>:is(h1,.h1,h2,.h2,h3,.h3,h4,.h4,h5,.h5) {
+  background-color: transparent;
+}

--- a/src/ansys_sphinx_theme/assets/styles/pydata-sphinx-theme-custom.scss
+++ b/src/ansys_sphinx_theme/assets/styles/pydata-sphinx-theme-custom.scss
@@ -922,6 +922,10 @@ code, kbd, pre, samp {
  * Target style for headings
   */
 
-.bd-main .bd-content .bd-article-container .bd-article :target>:is(h1,.h1,h2,.h2,h3,.h3,h4,.h4,h5,.h5) {
-  background-color: transparent;
+.bd-main .bd-content .bd-article-container .bd-article {
+  :target {
+    > :is(h1, .h1, h2, .h2, h3, .h3, h4, .h4, h5, .h5) {
+      background-color: transparent;
+    }
+  }
 }


### PR DESCRIPTION
fix #985 

## before

<img width="1160" height="423" alt="Screenshot 2026-05-22 at 14 28 43" src="https://github.com/user-attachments/assets/844a78cf-fe16-4040-9da8-b32de7d37a93" />

## After
- Given a transparent header as per UI/UX
<img width="1141" height="369" alt="Screenshot 2026-05-22 at 14 27 24" src="https://github.com/user-attachments/assets/1d33a3cd-7f20-4d50-8df9-6b770217529c" />
